### PR TITLE
[support] update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,13 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$android_tools_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.github.gnosis.bivrost-kotlin:bivrost-gradle-plugin:$bivrost_version"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         okhttp_version = "3.10.0"
 
         bivrost_version = "v0.6.2"
-        kmnid_version = "0.1"
+        kmnid_version = "0.2.1"
         kethereum_version = "0.53"
         khex_version = "0.5"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,17 +4,17 @@ buildscript {
 
     ext {
 
-        kotlin_version = '1.2.41'
-        android_tools_version = "3.1.2"
+        kotlin_version = '1.2.51'
+        android_tools_version = "3.2.0-beta02"
 
         build_tools_version = "27.0.3"
 
-        min_sdk_version = 23 //the uport-android-signer lib as of v0.0.1 requires minSDK 23
+        min_sdk_version = 19
         compile_sdk_version = 27
         target_sdk_version = compile_sdk_version
 
         test_runner_version = "1.0.1"
-        support_lib_version = "27.0.2"
+        support_lib_version = "27.1.1"
         play_services_version = "15.0.0"
         espresso_version = "3.0.1"
         junit_version = "4.12"
@@ -26,10 +26,10 @@ buildscript {
 
         bivrost_version = "v0.6.2"
         kmnid_version = "0.1"
-        kethereum_version = "0.40"
+        kethereum_version = "0.53"
         khex_version = "0.5"
 
-        uport_signer_version = "0.1.1"
+        uport_signer_version = "0.2.0"
         uport_sdk_version = "0.0.2"
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,10 +27,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    api "com.squareup.okhttp3:okhttp:$okhttp_version"
-    api "com.github.uport-project:kmnid:$kmnid_version"
+    implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
+    implementation "com.github.uport-project:kmnid:$kmnid_version"
+    implementation "com.github.walleth.kethereum:functions:$kethereum_version"
 
-    implementation "com.android.support:support-annotations:$support_lib_version"
+//    implementation "com.android.support:support-annotations:$support_lib_version"
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/core/src/main/java/me/uport/sdk/core/IFuelTokenProvider.kt
+++ b/core/src/main/java/me/uport/sdk/core/IFuelTokenProvider.kt
@@ -9,11 +9,11 @@ interface IFuelTokenProvider {
 
 
 suspend fun IFuelTokenProvider.onCreateFuelToken(deviceAddress: String): String = suspendCoroutine {
-    this.onCreateFuelToken(deviceAddress, { err, fuelToken ->
+    this.onCreateFuelToken(deviceAddress) { err, fuelToken ->
         if (err != null) {
             it.resumeWithException(err)
         } else {
             it.resume(fuelToken)
         }
-    })
+    }
 }

--- a/did/build.gradle
+++ b/did/build.gradle
@@ -16,10 +16,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        multiDexEnabled true
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {
@@ -29,18 +26,16 @@ android {
         }
     }
 
-    dexOptions {
-        jumboMode true
-    }
-
 }
 
 dependencies {
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
-    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
+//    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
 
-    api project(":jsonrpc")
+    implementation "com.github.walleth.kethereum:extensions:$kethereum_version"
+
+    implementation project(":jsonrpc")
     implementation project(":core")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/did/build.gradle
+++ b/did/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-        maven { url "https://jitpack.io" }
-    }
-
-    dependencies {
-        classpath ("com.github.gnosis.bivrost-kotlin:bivrost-gradle-plugin:$bivrost_version")
-    }
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "bivrost"

--- a/did/src/main/java/me/uport/sdk/did/DIDResolver.kt
+++ b/did/src/main/java/me/uport/sdk/did/DIDResolver.kt
@@ -94,15 +94,15 @@ class DIDResolver {
      */
     fun getProfileDocument(mnid: String, callback: (err: Exception?, ddo: DDO) -> Unit) {
 
-        Thread({
+        Thread {
             //safe to call networks
             val ddo = getProfileDocumentSync(mnid)
 
             //return to UI thread
-            Handler(Looper.getMainLooper()).post({
+            Handler(Looper.getMainLooper()).post {
                 callback(null, ddo!!)
-            })
-        }).run()
+            }
+        }.run()
 
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 27 15:29:24 EEST 2018
+#Fri Jun 22 11:10:48 EEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -14,7 +14,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
+        multiDexEnabled = true
     }
 
     buildTypes {
@@ -36,11 +36,11 @@ dependencies {
 //    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
-    api project(":did")
+    implementation project(":did")
     implementation project(":core")
 
-    androidTestImplementation "com.android.support.test:runner:$test_runner_version"
-    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
+//    androidTestImplementation "com.android.support.test:runner:$test_runner_version"
+//    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
     testImplementation "junit:junit:$junit_version"
 
 

--- a/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
@@ -91,21 +91,21 @@ class AccountCreator(
                         oldBundle.deviceAddress,
                         oldBundle.recoveryAddress,
                         networkId,
-                        oldBundle.fuelToken,
-                        { err, identityInfo ->
-                            if (err != null) {
-                                return@requestIdentityCreation fail(err, callback)
-                            }
-                            val bundle = oldBundle.copy(txHash = identityInfo.txHash ?: "")
-                            progress.save(AccountCreationState.PROXY_CREATION_SENT, bundle)
+                        oldBundle.fuelToken
+                ) { err, identityInfo ->
+                    if (err != null) {
+                        return@requestIdentityCreation fail(err, callback)
+                    }
+                    val bundle = oldBundle.copy(txHash = identityInfo.txHash ?: "")
+                    progress.save(AccountCreationState.PROXY_CREATION_SENT, bundle)
 
-                            return@requestIdentityCreation createAccount(networkId, false, callback)
-                        })
+                    return@requestIdentityCreation createAccount(networkId, false, callback)
+                }
 
             }
 
             AccountCreationState.PROXY_CREATION_SENT -> {
-                Thread({
+                Thread {
                     var pollingDelay = POLLING_INTERVAL
                     while (state != AccountCreationState.COMPLETE) {
 
@@ -140,7 +140,7 @@ class AccountCreator(
                         //FIXME: use saner polling model.. coroutines maybe?
                         Thread.sleep(pollingDelay)
                     }
-                }).start()
+                }.start()
             }
             AccountCreationState.COMPLETE -> {
                 return callback(null, oldBundle.partialAccount)

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -29,12 +29,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
 //    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    api "com.github.walleth.kethereum:model:$kethereum_version"
-    api "com.github.walleth.kethereum:crypto:$kethereum_version"
-    api "com.github.walleth.kethereum:rlp:$kethereum_version"
-    api "com.github.walleth.kethereum:functions:$kethereum_version"
-    api "com.github.walleth.kethereum:extensions:$kethereum_version"
-    api "com.github.walleth:khex:$khex_version"
+    implementation "com.github.walleth.kethereum:model:$kethereum_version"
+    implementation "com.github.walleth.kethereum:rlp:$kethereum_version"
+    implementation "com.github.walleth.kethereum:functions:$kethereum_version"
 
     implementation project(":core")
 

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -12,8 +12,6 @@ android {
         versionCode 1
         versionName "1.0"
 
-        multiDexEnabled true
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -25,18 +23,12 @@ android {
         }
     }
 
-    dexOptions {
-        jumboMode true
-    }
-
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
     implementation "com.github.uport-project:uport-android-signer:$uport_signer_version"
-
-    api "com.github.walleth:kethereum:$kethereum_version"
 
     implementation project(":did")
     implementation project(":core")

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -14,6 +14,7 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
+        multiDexEnabled = true
     }
 
     buildTypes {
@@ -34,7 +35,7 @@ dependencies {
     implementation project(":core")
 
     testImplementation "junit:junit:$junit_version"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+//    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     androidTestImplementation "org.mockito:mockito-android:$mockito_version"

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTDecodeTest.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTDecodeTest.kt
@@ -32,16 +32,16 @@ class JWTDecodeTest {
 
     @Test
     fun splitEmptyToken() {
-        assertFails("Token must have 3 parts: Header, Payload, and Signature",  {
+        assertFails("Token must have 3 parts: Header, Payload, and Signature") {
             splitToken("")
-        })
+        }
     }
 
     @Test
     fun splitIncompleteToken() {
-        assertFails("Token must have 3 parts: Header, Payload, and signature", {
+        assertFails("Token must have 3 parts: Header, Payload, and signature") {
             splitToken(invalidTokenOnlyHeader)
-        })
+        }
     }
 
     @Test
@@ -63,28 +63,28 @@ class JWTDecodeTest {
 
     @Test
     fun decodesIncompleteToken() {
-        assertFailsWith<InvalidJWTException>("JWT Payload cannot be empty", {
+        assertFailsWith<InvalidJWTException>("JWT Payload cannot be empty") {
             JWTTools().decode((invalidTokenEmptyPayload))
-        })
+        }
 
-        assertFailsWith<InvalidJWTException>("JWT Headder cannot be empty", {
+        assertFailsWith<InvalidJWTException>("JWT Headder cannot be empty") {
             JWTTools().decode((invalidTokenEmptyHeader))
-        })
+        }
     }
 
     @Test
     fun decodesRandomStuff() {
-        assertFailsWith<InvalidJWTException>("Invalid JSON format", {
+        assertFailsWith<InvalidJWTException>("Invalid JSON format") {
             JWTTools().decode("blahhh.blahhh.blahhh")
-        })
+        }
 
-        assertFailsWith<InvalidJWTException>("Invalid JSON format", {
+        assertFailsWith<InvalidJWTException>("Invalid JSON format") {
             JWTTools().decode("$validTokenHeader.blahhh.blahhh")
-        })
+        }
 
-        assertFailsWith<InvalidJWTException>("Invalid JSON format", {
+        assertFailsWith<InvalidJWTException>("Invalid JSON format") {
             JWTTools().decode("blahhh.$validShareReqTokenPayload.blahhh")
-        })
+        }
 
     }
 

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -30,20 +30,20 @@ class JWTToolsTests {
     @Test
     fun testVerifyToken() {
         val latch = CountDownLatch(2)
-        JWTTools().verify(validShareReqToken1, { err, actualPayload ->
+        JWTTools().verify(validShareReqToken1) { err, actualPayload ->
             assertNull(err)
             assertEquals(expectedShareReqPayload1, actualPayload)
             Log.d("herehere", "verify1")
             latch.countDown()
-        })
+        }
 
 
-        JWTTools().verify(incomingJwt, { err, actualPayload ->
+        JWTTools().verify(incomingJwt) { err, actualPayload ->
             assertNull(err)
             assertEquals(incomingJwtPayload, actualPayload)
             Log.d("herehere", "verify2")
             latch.countDown()
-        })
+        }
 
         latch.await()
     }
@@ -101,10 +101,10 @@ class JWTToolsTests {
     private fun ensureSeedIsImported(phrase: String) {
         //ensure seed is imported
         val latch = CountDownLatch(1)
-        UportHDSigner().importHDSeed(mActivityRule.activity, KeyProtection.Level.SIMPLE, phrase, { err, _, _ ->
+        UportHDSigner().importHDSeed(mActivityRule.activity, KeyProtection.Level.SIMPLE, phrase) { err, _, _ ->
             assertNull(err)
             latch.countDown()
-        })
+        }
         latch.await()
     }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -54,10 +54,10 @@ class JWTTools {
         //XXX: This is the crux of the bad behavior. signJwtBundle expects a Base64 string as payload and it was receiving plain text
         val messageToSign = "$headerEncodedString.$payloadEncodedString".toBase64()
 
-        UportHDSigner().signJwtBundle(context, address, derivationPath, messageToSign, prompt, { err, signature ->
+        UportHDSigner().signJwtBundle(context, address, derivationPath, messageToSign, prompt) { err, signature ->
             val encodedJwt = "$headerEncodedString.$payloadEncodedString.${signature.getJoseEncoded()}"
             callback(err, encodedJwt)
-        })
+        }
     }
 
     /**
@@ -98,7 +98,7 @@ class JWTTools {
 
     fun verify(token: String, callback: (err: Exception?, payload: JwtPayload?) -> Unit) {
         val (_, payload, signatureBytes) = decode(token)
-        DIDResolver().getProfileDocument(payload.iss, { err, ddo ->
+        DIDResolver().getProfileDocument(payload.iss) { err, ddo ->
             if (err !== null)
                 return@getProfileDocument callback(err, null)
 
@@ -117,7 +117,7 @@ class JWTTools {
                     return@getProfileDocument callback(err, payload)
             }
             return@getProfileDocument callback(InvalidSignatureException("Signature invalid: Public Key Mismatch"), null)
-        })
+        }
     }
 
     /***

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.uport.sdk.signer.UportHDSigner
+import com.uport.sdk.signer.getJoseEncoded
 import me.uport.sdk.core.decodeBase64
 import me.uport.sdk.core.toBase64
 import me.uport.sdk.core.toBase64UrlSafe
@@ -54,7 +55,7 @@ class JWTTools {
         val messageToSign = "$headerEncodedString.$payloadEncodedString".toBase64()
 
         UportHDSigner().signJwtBundle(context, address, derivationPath, messageToSign, prompt, { err, signature ->
-            val encodedJwt = "$headerEncodedString.$payloadEncodedString.$signature"
+            val encodedJwt = "$headerEncodedString.$payloadEncodedString.${signature.getJoseEncoded()}"
             callback(err, encodedJwt)
         })
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,6 +11,8 @@ android {
         targetSdkVersion target_sdk_version
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -27,8 +29,10 @@ dependencies {
 
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$bivrost_version"
     implementation "com.github.uport-project:uport-android-signer:$uport_signer_version"
+
     api project(":identity")
     api project(":core")
+    api project(":jsonrpc")
 
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-        google()
-        maven { url "https://jitpack.io" }
-    }
-
-    dependencies {
-        classpath ("com.github.gnosis.bivrost-kotlin:bivrost-gradle-plugin:$bivrost_version")
-    }
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "bivrost"

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -104,7 +104,7 @@ object Uport {
         val creator = AccountCreator(config.applicationContext, config.fuelTokenProvider)
         return creator.createAccount(networkId) { err, acc ->
             if (err != null) {
-                Handler(getMainLooper()).post({ completion(err, acc) })
+                Handler(getMainLooper()).post { completion(err, acc) }
                 @Suppress("LABEL_NAME_CLASH")
                 return@createAccount
             }
@@ -112,7 +112,7 @@ object Uport {
             val serialized = acc.toJson()
             prefs.edit().putString(DEFAULT_ACCOUNT, serialized).apply()
 
-            Handler(getMainLooper()).post({ completion(err, acc) })
+            Handler(getMainLooper()).post { completion(err, acc) }
         }
     }
 

--- a/sdk/src/main/java/me/uport/sdk/signer/SimpleSigner.kt
+++ b/sdk/src/main/java/me/uport/sdk/signer/SimpleSigner.kt
@@ -2,23 +2,23 @@ package me.uport.sdk.signer
 
 import me.uport.sdk.core.Signer
 import org.kethereum.crypto.ECKeyPair
-import org.kethereum.crypto.Keys
+import org.kethereum.crypto.getAddress
+import org.kethereum.crypto.signMessage
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.SignatureData
 
-@Suppress("LiftReturnOrAssignment")
 class SimpleSigner(private val privateKey: String) : Signer {
 
-    override fun getAddress() = Keys.getAddress(ECKeyPair.create(privateKey.hexToBigInteger()))
+    override fun getAddress() = ECKeyPair.create(privateKey.hexToBigInteger()).getAddress()
 
     override fun signMessage(rawMessage: ByteArray, callback: (err: Exception?, sigData: SignatureData) -> Unit) {
 
         try {
-            val keyPair = ECKeyPair.Companion.create(privateKey.hexToBigInteger())
-            val sigData = org.kethereum.crypto.signMessage(rawMessage, keyPair)
-            return callback(null, sigData)
+            val keyPair = ECKeyPair.create(privateKey.hexToBigInteger())
+            val sigData = keyPair.signMessage(rawMessage)
+            callback(null, sigData)
         } catch (ex: Exception) {
-            return callback(ex, SignatureData())
+            callback(ex, SignatureData())
         }
 
     }


### PR DESCRIPTION
This changeset brings a much needed update to the set of dependencies.
The most notable are:
* kethereum 0.53
* uport-android-signer 0.2.1

Along with this, the tests and code that broke after the update have been adapted to fit the new APIs.