### PR TITLE
Default to KeyPair account

### DIFF
--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -32,7 +32,6 @@ configurations.all {
     resolutionStrategy {
         dependencySubstitution {
             substitute module("com.github.uport-project.uport-android-sdk:sdk:v$uport_sdk_version") with project(':sdk')
-            substitute module("com.github.uport-project.uport-android-sdk:fuelingservice:v$uport_sdk_version") with project(':fuelingservice')
         }
     }
 }
@@ -42,7 +41,6 @@ dependencies {
 
             // project(":did"),
             "com.github.uport-project.uport-android-sdk:sdk:v$uport_sdk_version",
-            "com.github.uport-project.uport-android-sdk:fuelingservice:v$uport_sdk_version",
 
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
             "com.android.support:appcompat-v7:$support_lib_version",

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DemoApplication.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DemoApplication.kt
@@ -2,7 +2,6 @@ package me.uport.sdk.demoapp
 
 import android.app.Application
 import me.uport.sdk.Uport
-import me.uport.sdk.fuelingservice.FuelTokenProvider
 
 class DemoApplication : Application() {
 
@@ -11,8 +10,6 @@ class DemoApplication : Application() {
 
         val config = Uport.Configuration()
                 .setApplicationContext(this)
-                .setFuelTokenProvider(
-                        FuelTokenProvider(this, "2p1yWKU8Ucd4vuHmYmc3fvcvTkYL11KXdjH"))
 
         Uport.initialize(config)
     }

--- a/identity/src/main/java/me/uport/sdk/identity/Account.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/Account.kt
@@ -22,7 +22,7 @@ data class Account(
         val network: String,
 
         @Json(name = "proxy")
-        val proxyAddress: String,
+        val publicAddress: String,
 
         @Json(name = "manager")
         val identityManagerAddress: String,
@@ -40,7 +40,7 @@ data class Account(
     val address : String
         get() = getMnid()
 
-    fun getMnid() = MNID.encode(network, proxyAddress)
+    fun getMnid() = MNID.encode(network, publicAddress)
 
     fun toJson(pretty: Boolean = false): String = adapter.indent(if (pretty) "  " else "").toJson(this)
 

--- a/identity/src/main/java/me/uport/sdk/identity/Account.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/Account.kt
@@ -34,7 +34,7 @@ data class Account(
         val fuelToken: String,
 
         @Json(name = "signerType")
-        val signerType: SignerType = SignerType.MetaIdentityManager
+        val signerType: SignerType = SignerType.KeyPair
 ) {
 
     val address : String

--- a/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
@@ -1,0 +1,5 @@
+package me.uport.sdk.identity
+
+interface AccountCreator {
+    fun createAccount(networkId: String, forceRestart: Boolean = false, callback: AccountCreatorCallback)
+}

--- a/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
@@ -1,5 +1,19 @@
 package me.uport.sdk.identity
 
+import kotlin.coroutines.experimental.suspendCoroutine
+
+typealias AccountCreatorCallback = (err: Exception?, acc: Account) -> Unit
+
 interface AccountCreator {
     fun createAccount(networkId: String, forceRestart: Boolean = false, callback: AccountCreatorCallback)
+}
+
+suspend fun AccountCreator.createAccount(networkId: String, forceRestart: Boolean): Account = suspendCoroutine { continuation ->
+    this.createAccount(networkId, forceRestart) { err, account ->
+        if (err != null) {
+            continuation.resumeWithException(err)
+        } else {
+            continuation.resume(account)
+        }
+    }
 }

--- a/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
@@ -1,0 +1,41 @@
+package me.uport.sdk.identity
+
+import android.content.Context
+import com.uport.sdk.signer.UportHDSigner
+import com.uport.sdk.signer.encryption.KeyProtection
+
+class KPAccountCreator(private val context: Context) : AccountCreator {
+
+    override fun createAccount(networkId: String, forceRestart: Boolean, callback: AccountCreatorCallback) {
+
+        val signer = UportHDSigner()
+
+        signer.createHDSeed(context, KeyProtection.Level.SIMPLE) { err, rootAddress, _ ->
+            if (err != null) {
+                return@createHDSeed callback(err, Account.blank)
+            }
+            signer.computeAddressForPath(context,
+                    rootAddress,
+                    Account.GENERIC_DEVICE_KEY_DERIVATION_PATH,
+                    "") { ex, deviceAddress, _ ->
+                if (ex != null) {
+                    return@computeAddressForPath callback(err, Account.blank)
+                }
+
+                val acc = Account(
+                        rootAddress,
+                        deviceAddress,
+                        networkId,
+                        deviceAddress,
+                        "",
+                        "",
+                        "",
+                        SignerType.KeyPair
+                )
+
+                return@computeAddressForPath callback(null, acc)
+            }
+        }
+    }
+
+}

--- a/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
@@ -12,7 +12,7 @@ import me.uport.sdk.identity.endpoints.requestIdentityCreation
 
 typealias AccountCreatorCallback = (err: Exception?, acc: Account) -> Unit
 
-class AccountCreator(
+class MetaIdentityAccountCreator(
         private val context: Context,
         private val fuelTokenProvider: IFuelTokenProvider) {
 

--- a/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
@@ -10,7 +10,7 @@ import me.uport.sdk.identity.endpoints.UnnuIdentityInfo
 import me.uport.sdk.identity.endpoints.lookupIdentityInfo
 import me.uport.sdk.identity.endpoints.requestIdentityCreation
 
-typealias AccountCreatorCallback = (err: Exception?, acc: Account) -> Unit
+
 
 class MetaIdentityAccountCreator(
         private val context: Context,

--- a/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
@@ -14,7 +14,7 @@ typealias AccountCreatorCallback = (err: Exception?, acc: Account) -> Unit
 
 class MetaIdentityAccountCreator(
         private val context: Context,
-        private val fuelTokenProvider: IFuelTokenProvider) {
+        private val fuelTokenProvider: IFuelTokenProvider) : AccountCreator {
 
     private val progress: ProgressPersistence = ProgressPersistence(context)
 
@@ -28,7 +28,7 @@ class MetaIdentityAccountCreator(
      *
      * To force the creation of a new identity, use [forceRestart]
      */
-    fun createAccount(networkId: String, forceRestart: Boolean = false, callback: AccountCreatorCallback) {
+    override fun createAccount(networkId: String, forceRestart: Boolean, callback: AccountCreatorCallback) {
 
         var (state, oldBundle) = if (forceRestart) {
             (AccountCreationState.NONE to PersistentBundle())

--- a/sdk/src/main/java/me/uport/sdk/Transactions.kt
+++ b/sdk/src/main/java/me/uport/sdk/Transactions.kt
@@ -48,11 +48,11 @@ class Transactions(
                 nonce = rpcRelay.getTransactionCount(account.deviceAddress)
             }
             MetaIdentityManager -> {
-                from = Address(account.proxyAddress)
+                from = Address(account.publicAddress)
                 nonce = TxRelayHelper(network).resolveMetaNonce(account.deviceAddress)
             }
             Proxy, IdentityManager -> {
-                from = Address(account.proxyAddress)
+                from = Address(account.publicAddress)
             }
         }
 
@@ -91,7 +91,7 @@ class Transactions(
 
         val txHash = if (signerType == MetaIdentityManager) {
 
-            val metaSigner = MetaIdentitySigner(relaySigner, account.proxyAddress, account.identityManagerAddress)
+            val metaSigner = MetaIdentitySigner(relaySigner, account.publicAddress, account.identityManagerAddress)
             val signedEncodedTx = metaSigner.signRawTx(unsigned)
 
             relayMetaTransaction(signedEncodedTx)

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import me.uport.sdk.core.EthNetwork
 import me.uport.sdk.identity.Account
-import me.uport.sdk.identity.MetaIdentityAccountCreator
 import me.uport.sdk.identity.AccountCreatorCallback
 import me.uport.sdk.identity.IFuelTokenProvider
+import me.uport.sdk.identity.KPAccountCreator
 import kotlin.coroutines.experimental.suspendCoroutine
 
 object Uport {
@@ -71,7 +71,7 @@ object Uport {
      * The created account is saved as [defaultAccount] before returning with a result
      *
      */
-    suspend fun createAccount(network: EthNetwork) : Account = suspendCoroutine { cont ->
+    suspend fun createAccount(network: EthNetwork): Account = suspendCoroutine { cont ->
         this.createAccount(network) { err, acc ->
             if (err != null) {
                 cont.resumeWithException(err)
@@ -97,11 +97,11 @@ object Uport {
 
         //single account limitation should disappear in future versions
         if (defaultAccount != null) {
-            launch(UI) { completion(null, defaultAccount!!)}
+            launch(UI) { completion(null, defaultAccount!!) }
             return
         }
 
-        val creator = MetaIdentityAccountCreator(config.applicationContext, config.fuelTokenProvider)
+        val creator = KPAccountCreator(config.applicationContext)
         return creator.createAccount(networkId) { err, acc ->
             if (err != null) {
                 Handler(getMainLooper()).post { completion(err, acc) }

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import me.uport.sdk.core.EthNetwork
 import me.uport.sdk.identity.Account
-import me.uport.sdk.identity.AccountCreator
+import me.uport.sdk.identity.MetaIdentityAccountCreator
 import me.uport.sdk.identity.AccountCreatorCallback
 import me.uport.sdk.identity.IFuelTokenProvider
 import kotlin.coroutines.experimental.suspendCoroutine
@@ -101,7 +101,7 @@ object Uport {
             return
         }
 
-        val creator = AccountCreator(config.applicationContext, config.fuelTokenProvider)
+        val creator = MetaIdentityAccountCreator(config.applicationContext, config.fuelTokenProvider)
         return creator.createAccount(networkId) { err, acc ->
             if (err != null) {
                 Handler(getMainLooper()).post { completion(err, acc) }

--- a/sdk/src/main/java/me/uport/sdk/extensions/TransactionExtensions.kt
+++ b/sdk/src/main/java/me/uport/sdk/extensions/TransactionExtensions.kt
@@ -40,7 +40,7 @@ suspend fun Account.send(context: Context, destinationAddress: String, value: Bi
     val rawTransaction = createTransactionWithDefaults(
             value = value,
             to = Address(destinationAddress),
-            from = Address(this.proxyAddress)
+            from = Address(this.publicAddress)
     )
 
     return Transactions(this)
@@ -57,7 +57,7 @@ suspend fun Account.send(context: Context, contractAddress: String, data: ByteAr
     val rawTransaction = createTransactionWithDefaults(
             input = data.toList(),
             to = Address(contractAddress),
-            from = Address(this.proxyAddress),
+            from = Address(this.publicAddress),
             value = BigInteger.ZERO
     )
 


### PR DESCRIPTION
As the uPort targets shift, so must the libraries.
This changeset makes the default account created by the SDK a simple `KeyPair` account instead of a `MetaIdentityManager`-proxy contract account.

This is a breaking change.

There is no need to include the fuelingservice anymore since KP accounts have to be self-funded.