### PR TITLE
update default account after creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext {
 
         kotlin_version = '1.2.51'
-        android_tools_version = "3.2.0-beta02"
+        android_tools_version = "3.3.0-alpha03"
 
         build_tools_version = "27.0.3"
 
@@ -18,7 +18,8 @@ buildscript {
         play_services_version = "15.0.0"
         espresso_version = "3.0.1"
         junit_version = "4.12"
-        mockito_version = "2.12.0"
+        mockito_version = "2.18.3"
+        mockito_kotlin_version = "1.5.0"
 
         coroutines_version = "0.22.5"
         moshi_version = "1.6.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -1,0 +1,37 @@
+package me.uport.sdk
+
+import android.support.test.InstrumentationRegistry
+import kotlinx.coroutines.experimental.runBlocking
+import me.uport.sdk.core.Networks
+import me.uport.sdk.identity.Account
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+class UportTest {
+
+    @Before
+    fun run_before_every_test() {
+        val config = Uport.Configuration()
+                .setApplicationContext(InstrumentationRegistry.getTargetContext())
+        Uport.initialize(config)
+    }
+
+    @Test
+    fun default_account_gets_updated() {
+
+        val tested = Uport
+
+        tested.defaultAccount = null
+
+        runBlocking {
+            val acc = tested.createAccount(Networks.rinkeby)
+            assertNotNull(acc)
+            assertNotEquals(Account.blank, acc)
+
+            assertNotNull(tested.defaultAccount)
+        }
+    }
+
+}

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -111,6 +111,7 @@ object Uport {
 
             val serialized = acc.toJson()
             prefs.edit().putString(DEFAULT_ACCOUNT, serialized).apply()
+            defaultAccount = defaultAccount ?: acc
 
             Handler(getMainLooper()).post { completion(err, acc) }
         }


### PR DESCRIPTION
### What's here

On initial account creation, `Uport.defaultAccount` only gets updated after an app restart (#11)
This PR includes a test to validate this scenario and a fix for the bug

### Testing

Run `./gradlew :sdk:cC` with an emulator/device connected. It should also go through the respective test.