### PR TITLE
Add option to import seeds

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     implementation project(":did")
     implementation project(":core")
 
-//    androidTestImplementation "com.android.support.test:runner:$test_runner_version"
-//    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
+    androidTestImplementation "com.android.support.test:runner:$test_runner_version"
+    androidTestImplementation "com.android.support.test:rules:$test_runner_version"
     testImplementation "junit:junit:$junit_version"
 
 

--- a/identity/src/androidTest/java/KPAccountCreatorTest.kt
+++ b/identity/src/androidTest/java/KPAccountCreatorTest.kt
@@ -5,13 +5,12 @@ import android.support.test.InstrumentationRegistry
 import kotlinx.coroutines.experimental.runBlocking
 import me.uport.sdk.core.Networks
 import org.junit.Assert.*
-import org.junit.Test
-
 import org.junit.Before
+import org.junit.Test
 
 class KPAccountCreatorTest {
 
-    lateinit var appContext: Context
+    private lateinit var appContext: Context
 
     @Before
     fun run_before_every_test() {
@@ -28,6 +27,23 @@ class KPAccountCreatorTest {
             assertTrue(account.address.isNotEmpty())
             assertTrue(account.publicAddress.isNotEmpty())
             assertTrue(account.deviceAddress.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun importAccount() {
+
+        val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+
+        runBlocking {
+            val account = KPAccountCreator(appContext).importAccount(Networks.rinkeby.network_id, referenceSeedPhrase)
+            assertNotNull(account)
+            assertNotEquals(Account.blank, account)
+            assertTrue(account.signerType == SignerType.KeyPair)
+            assertEquals("2opxPamUQoLarQHAoVDKo2nDNmfQLNCZif4", account.address)
+            assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.publicAddress)
+            assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.deviceAddress)
+            assertEquals("0x794adde0672914159c1b77dd06d047904fe96ac8", account.handle)
         }
     }
 }

--- a/identity/src/androidTest/java/KPAccountCreatorTest.kt
+++ b/identity/src/androidTest/java/KPAccountCreatorTest.kt
@@ -1,0 +1,33 @@
+package me.uport.sdk.identity
+
+import android.content.Context
+import android.support.test.InstrumentationRegistry
+import kotlinx.coroutines.experimental.runBlocking
+import me.uport.sdk.core.Networks
+import org.junit.Assert.*
+import org.junit.Test
+
+import org.junit.Before
+
+class KPAccountCreatorTest {
+
+    lateinit var appContext: Context
+
+    @Before
+    fun run_before_every_test() {
+        appContext = InstrumentationRegistry.getTargetContext()
+    }
+
+    @Test
+    fun createAccount() {
+        runBlocking {
+            val account = KPAccountCreator(appContext).createAccount(Networks.rinkeby.network_id)
+            assertNotNull(account)
+            assertNotEquals(Account.blank, account)
+            assertTrue(account.signerType == SignerType.KeyPair)
+            assertTrue(account.address.isNotEmpty())
+            assertTrue(account.publicAddress.isNotEmpty())
+            assertTrue(account.deviceAddress.isNotEmpty())
+        }
+    }
+}

--- a/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
@@ -6,10 +6,22 @@ typealias AccountCreatorCallback = (err: Exception?, acc: Account) -> Unit
 
 interface AccountCreator {
     fun createAccount(networkId: String, forceRestart: Boolean = false, callback: AccountCreatorCallback)
+
+    fun importAccount(networkId: String, seedPhrase: String, forceRestart: Boolean, callback: AccountCreatorCallback)
 }
 
-suspend fun AccountCreator.createAccount(networkId: String, forceRestart: Boolean): Account = suspendCoroutine { continuation ->
+suspend fun AccountCreator.createAccount(networkId: String, forceRestart: Boolean = false): Account = suspendCoroutine { continuation ->
     this.createAccount(networkId, forceRestart) { err, account ->
+        if (err != null) {
+            continuation.resumeWithException(err)
+        } else {
+            continuation.resume(account)
+        }
+    }
+}
+
+suspend fun AccountCreator.importAccount(networkId: String, seedPhrase: String, forceRestart: Boolean = false): Account = suspendCoroutine { continuation ->
+    this.importAccount(networkId, seedPhrase, forceRestart) { err, account ->
         if (err != null) {
             continuation.resumeWithException(err)
         } else {

--- a/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
@@ -3,27 +3,22 @@ package me.uport.sdk.identity
 import android.content.Context
 import com.uport.sdk.signer.UportHDSigner
 import com.uport.sdk.signer.encryption.KeyProtection
+import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.launch
 
-class KPAccountCreator(private val context: Context) : AccountCreator {
+class KPAccountCreator(private val appContext: Context) : AccountCreator {
 
     override fun createAccount(networkId: String, forceRestart: Boolean, callback: AccountCreatorCallback) {
-
-        val signer = UportHDSigner()
-
-        signer.createHDSeed(context, KeyProtection.Level.SIMPLE) { err, rootAddress, _ ->
-            if (err != null) {
-                return@createHDSeed callback(err, Account.blank)
-            }
-            signer.computeAddressForPath(context,
-                    rootAddress,
-                    Account.GENERIC_DEVICE_KEY_DERIVATION_PATH,
-                    "") { ex, deviceAddress, _ ->
-                if (ex != null) {
-                    return@computeAddressForPath callback(err, Account.blank)
-                }
-
-                val acc = Account(
-                        rootAddress,
+        launch {
+            val signer = UportHDSigner()
+            try {
+                val (handle, _) = signer.createHDSeed(appContext, KeyProtection.Level.SIMPLE)
+                val (deviceAddress, _) = signer.computeAddressForPath(appContext,
+                        handle,
+                        Account.GENERIC_DEVICE_KEY_DERIVATION_PATH,
+                        "")
+                val account = Account(
+                        handle,
                         deviceAddress,
                         networkId,
                         deviceAddress,
@@ -33,8 +28,11 @@ class KPAccountCreator(private val context: Context) : AccountCreator {
                         SignerType.KeyPair
                 )
 
-                return@computeAddressForPath callback(null, acc)
+                launch(UI) { callback(null, account) }
+            } catch (err: Exception) {
+                launch(UI) { callback(err, Account.blank) }
             }
+
         }
     }
 

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -47,4 +47,22 @@ class UportTest {
         latch.await(15, TimeUnit.SECONDS)
     }
 
+    @Test
+    fun account_can_be_imported() {
+        val tested = Uport
+        val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+
+        tested.defaultAccount = null
+
+        runBlocking {
+            val account = tested.createAccount(Networks.rinkeby, referenceSeedPhrase)
+            assertNotNull(account)
+            assertNotEquals(Account.blank, account)
+            assertEquals("2opxPamUQoLarQHAoVDKo2nDNmfQLNCZif4", account.address)
+            assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.publicAddress)
+            assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.deviceAddress)
+            assertEquals("0x794adde0672914159c1b77dd06d047904fe96ac8", account.handle)
+        }
+    }
+
 }

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -1,5 +1,6 @@
 package me.uport.sdk
 
+import android.os.Looper
 import android.support.test.InstrumentationRegistry
 import kotlinx.coroutines.experimental.runBlocking
 import me.uport.sdk.core.Networks
@@ -8,6 +9,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class UportTest {
 
@@ -32,6 +34,17 @@ class UportTest {
 
             assertNotNull(tested.defaultAccount)
         }
+    }
+
+    @Test
+    fun account_completion_called_on_main_thread() {
+        val latch = CountDownLatch(1)
+        Uport.createAccount(Networks.rinkeby) { _, _ ->
+            assertTrue(Looper.getMainLooper().isCurrentThread)
+            latch.countDown()
+        }
+
+        latch.await(15, TimeUnit.SECONDS)
     }
 
 }


### PR DESCRIPTION
### What's here

For recovery purposes, the SDK must provide a way to create accounts from a seed phrase.
This PR fixes #7 by allowing `Uport.createAccount` to receive a seed phrase and exposing an `importAccount` in the `AccountCreator` interface in the `identity` module

### Testing
I added tests to cover the new functionality.
They can be run by `./gradlew cC` with a device/emulator connected.