### PR TITLE
[feature] add option to delete account

### DIFF
--- a/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/AccountCreator.kt
@@ -8,6 +8,8 @@ interface AccountCreator {
     fun createAccount(networkId: String, forceRestart: Boolean = false, callback: AccountCreatorCallback)
 
     fun importAccount(networkId: String, seedPhrase: String, forceRestart: Boolean, callback: AccountCreatorCallback)
+
+    fun deleteAccount(handle: String)
 }
 
 suspend fun AccountCreator.createAccount(networkId: String, forceRestart: Boolean = false): Account = suspendCoroutine { continuation ->
@@ -29,3 +31,5 @@ suspend fun AccountCreator.importAccount(networkId: String, seedPhrase: String, 
         }
     }
 }
+
+fun AccountCreator.deleteAccount(acc: Account) = this.deleteAccount(acc.handle)

--- a/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/KPAccountCreator.kt
@@ -8,9 +8,10 @@ import me.uport.sdk.core.UI
 
 class KPAccountCreator(private val appContext: Context) : AccountCreator {
 
+    val signer = UportHDSigner()
+
     private fun createOrImportAccount(networkId: String, phrase: String?, callback: AccountCreatorCallback) {
         launch {
-            val signer = UportHDSigner()
             try {
                 val (handle, _) = if (phrase.isNullOrBlank()) {
                     signer.createHDSeed(appContext, KeyProtection.Level.SIMPLE)
@@ -46,6 +47,10 @@ class KPAccountCreator(private val appContext: Context) : AccountCreator {
 
     override fun importAccount(networkId: String, seedPhrase: String, forceRestart: Boolean, callback: AccountCreatorCallback) {
         createOrImportAccount(networkId, seedPhrase, callback)
+    }
+
+    override fun deleteAccount(handle: String) {
+        signer.deleteSeed(appContext, handle)
     }
 
 }

--- a/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/MetaIdentityAccountCreator.kt
@@ -17,6 +17,8 @@ class MetaIdentityAccountCreator(
 
     private val progress: ProgressPersistence = ProgressPersistence(context)
 
+    private val signer = UportHDSigner()
+
     /**
      * Creates a new identity on the uPort platform.
      *
@@ -34,8 +36,6 @@ class MetaIdentityAccountCreator(
         } else {
             progress.restore()
         }
-
-        val signer = UportHDSigner()
 
         when (state) {
 
@@ -166,6 +166,10 @@ class MetaIdentityAccountCreator(
 
     override fun importAccount(networkId: String, seedPhrase: String, forceRestart: Boolean, callback: AccountCreatorCallback) {
         createOrImportAccount(networkId, seedPhrase, forceRestart, callback)
+    }
+
+    override fun deleteAccount(handle: String) {
+        signer.deleteSeed(context, handle)
     }
 
     private fun fail(err: Exception, callback: AccountCreatorCallback) {

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -1,7 +1,9 @@
 package me.uport.sdk
 
+import android.content.Context
 import android.os.Looper
 import android.support.test.InstrumentationRegistry
+import com.uport.sdk.signer.UportHDSigner
 import kotlinx.coroutines.experimental.runBlocking
 import me.uport.sdk.core.Networks
 import me.uport.sdk.identity.Account
@@ -13,10 +15,14 @@ import java.util.concurrent.TimeUnit
 
 class UportTest {
 
+    lateinit var context : Context
+
     @Before
     fun run_before_every_test() {
+        context = InstrumentationRegistry.getTargetContext()
         val config = Uport.Configuration()
-                .setApplicationContext(InstrumentationRegistry.getTargetContext())
+                .setApplicationContext(context)
+
         Uport.initialize(config)
     }
 
@@ -62,6 +68,25 @@ class UportTest {
             assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.publicAddress)
             assertEquals("0x847e5e3e8b2961c2225cb4a2f719d5409c7488c6", account.deviceAddress)
             assertEquals("0x794adde0672914159c1b77dd06d047904fe96ac8", account.handle)
+        }
+    }
+
+    @Test
+    fun can_delete_account() {
+        val tested = Uport
+
+        tested.defaultAccount = null
+
+        runBlocking {
+            val account = tested.createAccount(Networks.rinkeby)
+            assertNotNull(account)
+            assertNotEquals(Account.blank, account)
+
+            val root = account.handle
+            tested.deleteAccount(root)
+
+            assertFalse(UportHDSigner().allHDRoots(context).contains(root))
+            assertNull(tested.defaultAccount)
         }
     }
 

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -124,7 +124,12 @@ object Uport {
         }
 
         accountCreator.deleteAccount(rootHandle)
+        if (rootHandle == defaultAccount?.handle) {
+            defaultAccount = null
+        }
     }
+
+    fun deleteAccount(acc: Account) = deleteAccount(acc.handle)
 
     class Configuration {
 


### PR DESCRIPTION
### What's here

This changeset adds `deleteAccount` functionality.
Since the SDK is using HD accounts, the actual thing being deleted is the seed from protected storage.
If the account being deleted is the default one, that is cleared as well.

### Testing

with an emulator / device connected, simply run `./gradlew cC` which will run the entire instrumented test suite including the test for account deletion