### PR TITLE
Add support for multiple accounts

### DIFF
--- a/identity/src/main/java/me/uport/sdk/identity/Account.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/Account.kt
@@ -34,7 +34,10 @@ data class Account(
         val fuelToken: String,
 
         @Json(name = "signerType")
-        val signerType: SignerType = SignerType.KeyPair
+        val signerType: SignerType = SignerType.KeyPair,
+
+        @Json(name = "isDefault")
+        val isDefault: Boolean? = false
 ) {
 
     val address : String

--- a/identity/src/test/java/me/uport/sdk/identity/AccountSerializationTests.kt
+++ b/identity/src/test/java/me/uport/sdk/identity/AccountSerializationTests.kt
@@ -1,0 +1,35 @@
+package me.uport.sdk.identity
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class AccountSerializationTests {
+
+    @Test
+    fun `can deserialize account with optional field`() {
+
+        //language=JSON
+        val serializedAccount = """
+            {
+              "uportRoot":"0xrootAddress",
+              "devKey":"0xaddress",
+              "network":"0x4",
+              "proxy":"0xpublicaddress",
+              "manager":"0xidentityManagerAddress",
+              "txRelay":"0xtxRelayAddress",
+              "fuelToken":"base64FuelToken",
+              "signerType":"KeyPair"
+            }""".trimIndent()
+
+        val account = Account.fromJson(serializedAccount)
+
+        assertNotNull(account)
+
+        account!!
+
+        assertNotNull(account.isDefault)
+        assertFalse(account.isDefault)
+    }
+
+}

--- a/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
+++ b/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
@@ -1,10 +1,28 @@
 package me.uport.sdk.identity
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.*
 import org.junit.Test
 
-class AccountSerializationTests {
+class AccountsTests {
+
+    @Test
+    fun `can serialize and deserialize account`() {
+        val acc = Account(
+                "0xroot",
+                "0xdevice",
+                "0x1",
+                "0xpublic",
+                "",
+                "",
+                ""
+        )
+
+        val serialized = acc.toJson()
+
+        val other = Account.fromJson(serialized)
+
+        assertEquals(acc, other)
+    }
 
     @Test
     fun `can deserialize account with optional field`() {
@@ -29,7 +47,8 @@ class AccountSerializationTests {
         account!!
 
         assertNotNull(account.isDefault)
-        assertFalse(account.isDefault)
+
+        assertFalse(account.isDefault!!)
     }
 
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
+    implementation "com.android.support:support-annotations:$support_lib_version"
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$bivrost_version"
 

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -97,6 +97,17 @@ class UportTest {
     }
 
     @Test
+    fun imported_account_can_be_retrieved() {
+        val tested = Uport
+        val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+
+        runBlocking {
+            val account = tested.createAccount(Networks.rinkeby, referenceSeedPhrase)
+            assertEquals(account, tested.getAccount("0x794adde0672914159c1b77dd06d047904fe96ac8"))
+        }
+    }
+
+    @Test
     fun can_delete_account() {
         val tested = Uport
 

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -46,7 +46,6 @@ class UportTest {
     fun there_can_be_only_one_default_account() {
 
         val tested = Uport
-        assertNotNull(tested.accountStorage)
 
         tested.defaultAccount?.let { tested.deleteAccount(it) }
 
@@ -55,16 +54,16 @@ class UportTest {
             val acc1 = tested.createAccount(Networks.rinkeby)
             assertEquals(acc1, tested.defaultAccount) //first account gets to be default
 
-            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1)
+            assertTrue(tested.allAccounts().filter { it.isDefault == true }.size == 1)
 
             val acc2 = tested.createAccount(Networks.rinkeby)
             assertNotEquals(acc2, tested.defaultAccount) //default isn't overwritten
 
-            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1) //still one
+            assertTrue(tested.allAccounts().filter { it.isDefault == true }.size == 1) //still one
 
             tested.defaultAccount = acc2
 
-            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1) //still one
+            assertTrue(tested.allAccounts().filter { it.isDefault == true }.size == 1) //still one
         }
     }
 

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 class UportTest {
 
-    lateinit var context : Context
+    lateinit var context: Context
 
     @Before
     fun run_before_every_test() {
@@ -31,7 +31,7 @@ class UportTest {
 
         val tested = Uport
 
-        tested.defaultAccount?.let{ tested.deleteAccount(it)}
+        tested.defaultAccount?.let { tested.deleteAccount(it) }
 
         runBlocking {
             val acc = tested.createAccount(Networks.rinkeby)
@@ -39,6 +39,32 @@ class UportTest {
             assertNotEquals(Account.blank, acc)
 
             assertNotNull(tested.defaultAccount)
+        }
+    }
+
+    @Test
+    fun there_can_be_only_one_default_account() {
+
+        val tested = Uport
+        assertNotNull(tested.accountStorage)
+
+        tested.defaultAccount?.let { tested.deleteAccount(it) }
+
+        runBlocking {
+
+            val acc1 = tested.createAccount(Networks.rinkeby)
+            assertEquals(acc1, tested.defaultAccount) //first account gets to be default
+
+            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1)
+
+            val acc2 = tested.createAccount(Networks.rinkeby)
+            assertNotEquals(acc2, tested.defaultAccount) //default isn't overwritten
+
+            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1) //still one
+
+            tested.defaultAccount = acc2
+
+            assertTrue(tested.accountStorage?.all()?.filter { it.isDefault == true }?.size == 1) //still one
         }
     }
 
@@ -58,7 +84,7 @@ class UportTest {
         val tested = Uport
         val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
 
-        tested.defaultAccount?.let{ tested.deleteAccount(it)}
+        tested.defaultAccount?.let { tested.deleteAccount(it) }
 
         runBlocking {
             val account = tested.createAccount(Networks.rinkeby, referenceSeedPhrase)
@@ -75,7 +101,7 @@ class UportTest {
     fun can_delete_account() {
         val tested = Uport
 
-        tested.defaultAccount?.let{ tested.deleteAccount(it)}
+        tested.defaultAccount?.let { tested.deleteAccount(it) }
 
         runBlocking {
             val account = tested.createAccount(Networks.rinkeby)

--- a/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
+++ b/sdk/src/androidTest/java/me/uport/sdk/UportTest.kt
@@ -31,7 +31,7 @@ class UportTest {
 
         val tested = Uport
 
-        tested.defaultAccount = null
+        tested.defaultAccount?.let{ tested.deleteAccount(it)}
 
         runBlocking {
             val acc = tested.createAccount(Networks.rinkeby)
@@ -58,7 +58,7 @@ class UportTest {
         val tested = Uport
         val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
 
-        tested.defaultAccount = null
+        tested.defaultAccount?.let{ tested.deleteAccount(it)}
 
         runBlocking {
             val account = tested.createAccount(Networks.rinkeby, referenceSeedPhrase)
@@ -75,7 +75,7 @@ class UportTest {
     fun can_delete_account() {
         val tested = Uport
 
-        tested.defaultAccount = null
+        tested.defaultAccount?.let{ tested.deleteAccount(it)}
 
         runBlocking {
             val account = tested.createAccount(Networks.rinkeby)

--- a/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
+++ b/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
@@ -12,15 +12,17 @@ interface AccountStorage {
 
 class InMemoryAccountStorage : AccountStorage {
 
+    private val accounts = mapOf<String, Account>().toMutableMap()
+
     override fun upsert(newAcc: Account) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        accounts[newAcc.handle] = newAcc
     }
 
     override fun get(handle: String): Account? {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        return accounts[handle]
     }
 
     override fun delete(handle: String) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        accounts.remove(handle)
     }
 }

--- a/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
+++ b/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
@@ -11,6 +11,8 @@ interface AccountStorage {
     fun delete(handle: String)
 
     fun all(): List<Account>
+
+    fun upsertAll(list: Collection<Account>)
 }
 
 
@@ -41,6 +43,14 @@ class SharedPrefsAcountStorage(
 
     override fun upsert(newAcc: Account) {
         accounts[newAcc.handle] = newAcc
+        persist()
+    }
+
+    override fun upsertAll(list: Collection<Account>) {
+        list.forEach {
+            accounts[it.handle] = it
+        }
+
         persist()
     }
 

--- a/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
+++ b/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
@@ -1,0 +1,26 @@
+package me.uport.sdk
+
+import me.uport.sdk.identity.Account
+
+interface AccountStorage {
+    fun upsert(newAcc: Account)
+
+    fun get(handle: String): Account?
+
+    fun delete(handle: String)
+}
+
+class InMemoryAccountStorage : AccountStorage {
+
+    override fun upsert(newAcc: Account) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun get(handle: String): Account? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun delete(handle: String) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
+++ b/sdk/src/main/java/me/uport/sdk/AccountStorage.kt
@@ -1,5 +1,6 @@
 package me.uport.sdk
 
+import android.content.SharedPreferences
 import me.uport.sdk.identity.Account
 
 interface AccountStorage {
@@ -8,21 +9,58 @@ interface AccountStorage {
     fun get(handle: String): Account?
 
     fun delete(handle: String)
+
+    fun all(): List<Account>
 }
 
-class InMemoryAccountStorage : AccountStorage {
+
+/**
+ * An account storage mechanism that relies on [SharedPreferences] for persistence to disk
+ *
+ * Accounts are loaded during construction and then relayed from memory
+ */
+class SharedPrefsAcountStorage(
+        private val prefs: SharedPreferences
+) : AccountStorage {
 
     private val accounts = mapOf<String, Account>().toMutableMap()
 
-    override fun upsert(newAcc: Account) {
-        accounts[newAcc.handle] = newAcc
+    init {
+        val set = prefs.getStringSet(KEY_ACCOUNTS, emptySet())
+        set.forEach { serialized ->
+            val acc = try {
+                Account.fromJson(serialized)
+            } catch (ex: Exception) {
+                null
+            }
+
+            acc?.let { upsert(it) }
+        }
     }
 
-    override fun get(handle: String): Account? {
-        return accounts[handle]
+
+    override fun upsert(newAcc: Account) {
+        accounts[newAcc.handle] = newAcc
+        persist()
     }
+
+    override fun get(handle: String): Account? = accounts[handle]
 
     override fun delete(handle: String) {
         accounts.remove(handle)
+        persist()
     }
+
+    override fun all(): List<Account> = accounts.values.toList()
+
+    private fun persist() {
+        prefs.edit()
+                .putStringSet(KEY_ACCOUNTS, accounts.values.map { it.toJson() }.toSet())
+                .apply()
+    }
+
+    companion object {
+        private const val KEY_ACCOUNTS = "accounts"
+    }
+
 }

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -43,8 +43,7 @@ object Uport {
             }
         }
 
-    @VisibleForTesting(otherwise = PRIVATE)
-    internal var accountStorage: AccountStorage? = null
+    private var accountStorage: AccountStorage? = null
 
     private const val UPORT_CONFIG: String = "uport_sdk_prefs"
 
@@ -141,12 +140,16 @@ object Uport {
                 accountStorage?.upsert(acc)
                 defaultAccount = defaultAccount ?: acc
 
-                launch(UI) { completion(null, acc) }
+                launch(UI) { completion(null, if (acc.handle == defaultAccount?.handle) defaultAccount!! else acc) }
             } catch (err: Exception) {
                 launch(UI) { completion(err, Account.blank) }
             }
         }
     }
+
+    fun getAccount(handle: String) = accountStorage?.get(handle)
+
+    fun allAccounts() = accountStorage?.all() ?: emptyList()
 
     fun deleteAccount(rootHandle: String) {
         if (!initialized) {

--- a/sdk/src/main/java/me/uport/sdk/Uport.kt
+++ b/sdk/src/main/java/me/uport/sdk/Uport.kt
@@ -95,12 +95,6 @@ object Uport {
             throw UportNotInitializedException()
         }
 
-        //FIXME: single account limitation should disappear in future versions
-        if (defaultAccount != null) {
-            launch(UI) { completion(null, defaultAccount!!) }
-            return
-        }
-
         launch {
             try {
                 val acc = if (seedPhrase.isNullOrBlank()) {
@@ -108,7 +102,7 @@ object Uport {
                 } else {
                     accountCreator.importAccount(networkId, seedPhrase!!)
                 }
-                prefs.edit().putString(DEFAULT_ACCOUNT, acc.toJson()).apply()
+                accountStorage?.upsert(acc)
                 defaultAccount = defaultAccount ?: acc
 
                 launch(UI) { completion(null, acc) }

--- a/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
+++ b/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
@@ -1,7 +1,7 @@
 package me.uport.sdk
 
 import me.uport.sdk.identity.Account
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AccountStorageTest {
@@ -11,7 +11,7 @@ class AccountStorageTest {
         val storage: AccountStorage = InMemoryAccountStorage()
         val newAcc = Account("0xnewaccount", "", "", "", "", "", "")
         storage.upsert(newAcc)
-        Assert.assertEquals(newAcc, storage.get("0xnewaccount"))
+        assertEquals(newAcc, storage.get("0xnewaccount"))
     }
 
 }

--- a/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
+++ b/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
@@ -1,0 +1,17 @@
+package me.uport.sdk
+
+import me.uport.sdk.identity.Account
+import org.junit.Assert
+import org.junit.Test
+
+class AccountStorageTest {
+
+    @Test
+    fun `can add new account`() {
+        val storage: AccountStorage = InMemoryAccountStorage()
+        val newAcc = Account("0xnewaccount", "", "", "", "", "", "")
+        storage.upsert(newAcc)
+        Assert.assertEquals(newAcc, storage.get("0xnewaccount"))
+    }
+
+}

--- a/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
+++ b/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
@@ -1,17 +1,86 @@
 package me.uport.sdk
 
+import me.uport.sdk.fakes.InMemorySharedPrefs
 import me.uport.sdk.identity.Account
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Test
 
 class AccountStorageTest {
 
     @Test
-    fun `can add new account`() {
-        val storage: AccountStorage = InMemoryAccountStorage()
+    fun `can add and retrieve new account`() {
+        val storage: AccountStorage = SharedPrefsAcountStorage(InMemorySharedPrefs())
         val newAcc = Account("0xnewaccount", "", "", "", "", "", "")
         storage.upsert(newAcc)
         assertEquals(newAcc, storage.get("0xnewaccount"))
+    }
+
+    @Test
+    fun `can show all accounts`() {
+        val storage: AccountStorage = SharedPrefsAcountStorage(InMemorySharedPrefs())
+
+        val accounts = (0..10).map {
+            Account("0x$it", "", "", "", "", "", "")
+        }.map {
+            storage.upsert(it)
+            it
+        }
+
+        val allAccounts = storage.all()
+
+        assertTrue(allAccounts.containsAll(accounts))
+    }
+
+    @Test
+    fun `can delete account`() {
+        val storage: AccountStorage = SharedPrefsAcountStorage(InMemorySharedPrefs())
+
+        val account = Account(
+                "0xmyAccount",
+                "device",
+                "0x1",
+                "0xpublic",
+                "",
+                "",
+                ""
+        )
+
+        storage.upsert(account)
+
+        storage.upsert(account)
+        assertEquals(account, storage.get(account.handle))
+
+        storage.delete(account.handle)
+
+        assertNull(storage.get(account.handle))
+        assertFalse(storage.all().contains(account))
+    }
+
+    @Test
+    fun `can overwrite account`() {
+        val storage: AccountStorage = SharedPrefsAcountStorage(InMemorySharedPrefs())
+
+        val account = Account(
+                "0xmyAccount",
+                "device",
+                "0x1",
+                "0xpublic",
+                "",
+                "",
+                ""
+        )
+
+        storage.upsert(account)
+
+        val newAccount = account.copy(isDefault = true)
+
+        storage.upsert(newAccount)
+
+        assertNotEquals(account, storage.get(account.handle))
+        assertEquals(newAccount, storage.get(account.handle))
+
+        assertFalse(storage.all().contains(account))
+        assertTrue(storage.all().contains(newAccount))
     }
 
 }

--- a/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
+++ b/sdk/src/test/java/me/uport/sdk/AccountStorageTest.kt
@@ -83,4 +83,19 @@ class AccountStorageTest {
         assertTrue(storage.all().contains(newAccount))
     }
 
+    @Test
+    fun `can upsert all`() {
+        val storage: AccountStorage = SharedPrefsAcountStorage(InMemorySharedPrefs())
+
+        val accounts = (0..10).map {
+            Account("0x$it", "", "", "", "", "", "")
+        }
+
+        storage.upsertAll(accounts)
+
+        val allAccounts = storage.all()
+
+        assertTrue(allAccounts.containsAll(accounts))
+    }
+
 }

--- a/sdk/src/test/java/me/uport/sdk/fakes/InMemoryAccountStorage.kt
+++ b/sdk/src/test/java/me/uport/sdk/fakes/InMemoryAccountStorage.kt
@@ -1,0 +1,24 @@
+package me.uport.sdk.fakes
+
+import me.uport.sdk.AccountStorage
+import me.uport.sdk.identity.Account
+
+/**
+ * volatile account storage, usable in tests
+ */
+class InMemoryAccountStorage : AccountStorage {
+
+    private val accounts = mapOf<String, Account>().toMutableMap()
+
+    override fun upsert(newAcc: Account) {
+        accounts[newAcc.handle] = newAcc
+    }
+
+    override fun get(handle: String): Account? = accounts[handle]
+
+    override fun delete(handle: String) {
+        accounts.remove(handle)
+    }
+
+    override fun all(): List<Account> = accounts.values.toList()
+}

--- a/sdk/src/test/java/me/uport/sdk/fakes/InMemoryAccountStorage.kt
+++ b/sdk/src/test/java/me/uport/sdk/fakes/InMemoryAccountStorage.kt
@@ -14,6 +14,12 @@ class InMemoryAccountStorage : AccountStorage {
         accounts[newAcc.handle] = newAcc
     }
 
+    override fun upsertAll(list: Collection<Account>) {
+        list.forEach {
+            accounts[it.handle] = it
+        }
+    }
+
     override fun get(handle: String): Account? = accounts[handle]
 
     override fun delete(handle: String) {

--- a/sdk/src/test/java/me/uport/sdk/fakes/InMemorySharedPrefs.kt
+++ b/sdk/src/test/java/me/uport/sdk/fakes/InMemorySharedPrefs.kt
@@ -1,0 +1,117 @@
+package me.uport.sdk.fakes
+
+import android.content.SharedPreferences
+
+/**
+ * fake sharedprefs usable during testing
+ */
+class InMemorySharedPrefs : SharedPreferences {
+
+    private val mapOfValues = emptyMap<String, Any?>().toMutableMap()
+
+    override fun contains(key: String?): Boolean = mapOfValues.containsKey(key)
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean =
+            if (mapOfValues[key] == null || mapOfValues[key] !is Boolean) {
+                defValue
+            } else {
+                mapOfValues[key] as Boolean
+            }
+
+
+    override fun getInt(key: String?, defValue: Int): Int =
+            if (mapOfValues[key] == null || mapOfValues[key] !is Int) {
+                defValue
+            } else {
+                mapOfValues[key] as Int
+            }
+
+
+    override fun getLong(key: String?, defValue: Long): Long =
+            if (mapOfValues[key] == null || mapOfValues[key] !is Long) {
+                defValue
+            } else {
+                mapOfValues[key] as Long
+            }
+
+    override fun getFloat(key: String?, defValue: Float): Float =
+            if (mapOfValues[key] == null || mapOfValues[key] !is Float) {
+                defValue
+            } else {
+                mapOfValues[key] as Float
+            }
+
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+            if (mapOfValues[key] == null || mapOfValues[key] !is MutableSet<*>) {
+                defValues
+            } else {
+                @Suppress("UNCHECKED_CAST")
+                mapOfValues[key] as MutableSet<String>
+            }
+
+
+    override fun getString(key: String?, defValue: String?): String? =
+            if (mapOfValues[key] == null || mapOfValues[key] !is String) {
+                defValue
+            } else {
+                mapOfValues[key] as String
+            }
+
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAll(): Map<String, *> = mapOfValues
+
+    override fun edit(): SharedPreferences.Editor {
+
+        return object : SharedPreferences.Editor {
+
+            override fun clear(): SharedPreferences.Editor = apply {
+                mapOfValues.clear()
+            }
+
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor = apply {
+                this@InMemorySharedPrefs.mapOfValues[key] = value
+            }
+
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor = apply {
+                this@InMemorySharedPrefs.mapOfValues[key] = value
+            }
+
+            override fun remove(key: String?): SharedPreferences.Editor = apply {
+                mapOfValues.remove(key)
+            }
+
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor = apply {
+                mapOfValues[key] = value
+            }
+
+            override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor = apply {
+                mapOfValues[key] = values
+            }
+
+            override fun commit(): Boolean {
+                return true
+            }
+
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor = apply {
+                mapOfValues[key] = value
+            }
+
+            override fun apply() {
+                //nop
+            }
+
+            override fun putString(key: String, value: String?): SharedPreferences.Editor = apply {
+                mapOfValues[key] = value
+            }
+        }
+
+    }
+}

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     api "com.github.walleth.kethereum:crypto:$kethereum_version"
     api "com.github.walleth.kethereum:bip39:$kethereum_version"
+    api project(":core")
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_rules_version"

--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -5,6 +5,9 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.uport.sdk.signer.encryption.KeyProtection.Level.SIMPLE
 import com.uport.sdk.signer.testutil.ensureSeedIsImportedInTargetContext
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/signer/src/androidTest/java/com/uport/sdk/signer/SignatureTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/SignatureTests.kt
@@ -3,6 +3,8 @@ package com.uport.sdk.signer
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.uport.sdk.signer.encryption.KeyProtection
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test

--- a/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.uport.sdk.signer.encryption.KeyProtection
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test

--- a/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
@@ -5,6 +5,8 @@ import com.uport.sdk.signer.UportSigner.Companion.ERR_ACTIVITY_DOES_NOT_EXIST
 import com.uport.sdk.signer.encryption.KeyProtection
 import com.uport.sdk.signer.testutil.ensureKeyIsImportedInTargetContext
 import com.uport.sdk.signer.testutil.ensureSeedIsImportedInTargetContext
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -3,6 +3,9 @@ package com.uport.sdk.signer
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import com.uport.sdk.signer.encryption.KeyProtection
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
 import org.kethereum.bip32.generateKey
 import org.kethereum.bip39.Mnemonic
 import org.kethereum.crypto.getAddress

--- a/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
@@ -8,12 +8,10 @@ import android.support.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.uport.sdk.signer.encryption.KeyProtection
 import com.uport.sdk.signer.encryption.KeyProtectionFactory
 import com.uport.sdk.signer.encryption.SimpleAsymmetricProtection
-import org.kethereum.crypto.ECKeyPair
-import org.kethereum.crypto.PUBLIC_KEY_SIZE
-import org.kethereum.crypto.createEcKeyPair
-import org.kethereum.crypto.getAddress
-import org.kethereum.crypto.signMessage
-import org.kethereum.crypto.signMessageHash
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.padBase64
+import me.uport.sdk.core.toBase64
+import org.kethereum.crypto.*
 import org.kethereum.hashes.sha256
 import org.kethereum.model.SignatureData
 import org.spongycastle.jce.provider.BouncyCastleProvider


### PR DESCRIPTION
### What's here

This brings support for multiple accounts in the SDK (fix for #15).
* added AccountStorage that can hold multiple accounts.
* there can be only one default account
* `Uport.defaultAccount` behaves the same, but is now a property (w `get()`/`set()`)
* added `Uport.getAccount(handle)`
* added `Uport.allAccounts()`
* when default account is deleted, other accounts can remain but are not automatically promoted to default.

### Testing

Just run `./gradlew test cC` with an emulator/device connected.