### PR TITLE
[Support] bump kethereum to 63

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ but that may be removed when pure kotlin implementations of the required cryptog
 * 0.3.x - upcoming release with breaking changes
     * add universal DID resolver
     * add cleaner way of creating JWTs with abstracted signer
+    * updated to kethereum 0.63 which has a different key derivation and mnemonic API.
+        If you're using an older version in parallel, you need to update as well. 
 
 * 0.2.2
     * update of dependencies for coroutines and build tools

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
 
         kotlin_version = '1.2.71'
         kotlin_serialization_version = '0.6.2'
-        coroutines_version = "0.26.1"
+        coroutines_version = "0.30.2"
 
-        android_tools_version = '3.3.0-alpha13'
+        android_tools_version = '3.3.0-beta01'
 
         build_tools_version = "28.0.3"
 
@@ -18,19 +18,19 @@ buildscript {
 
         test_runner_version = "1.0.2"
         test_rules_version = test_runner_version
-        support_lib_version = "27.1.1"
+        support_lib_version = "28.0.0"
         play_services_version = "15.0.0"
         espresso_version = "3.0.2"
         junit_version = "4.12"
-        mockito_version = "2.19.0"
-        mockito_kotlin_version = "2.0.0-RC1"
+        mockito_version = "2.23.0"
+        mockito_kotlin_version = "2.0.0-RC3"
 
         moshi_version = "1.7.0"
         okhttp_version = "3.10.0"
 
         bivrost_version = "1c0efeb7f3"//"v0.6.2"
         kmnid_version = "0.2.1"
-        kethereum_version = "0.53"
+        kethereum_version = "0.63"
         khex_version = "0.5"
 
         uport_sdk_version = "0.2.2"

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -52,7 +52,7 @@ class CredentialsTest {
         val cred = Credentials("did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX", KPSigner("0x1234"))
         val jwt = cred.signJWT(emptyMap())
 
-        val (header, payload, signature) = JWTTools().decode(jwt)
+        val (header, _, _) = JWTTools().decode(jwt)
         assertEquals(ES256K, header.alg)
 
     }
@@ -63,7 +63,7 @@ class CredentialsTest {
         val cred = Credentials("0xf3beac30c498d9e26865f34fcaa57dbb935b0d74", KPSigner("0x1234"))
         val jwt = cred.signJWT(emptyMap())
 
-        val (header, payload, signature) = JWTTools().decode(jwt)
+        val (header, _, _) = JWTTools().decode(jwt)
         assertEquals(ES256K_R, header.alg)
 
     }

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -17,7 +17,8 @@ import me.uport.sdk.jwt.model.JwtPayload
 import me.uport.sdk.serialization.mapAdapter
 import me.uport.sdk.serialization.moshi
 import org.kethereum.crypto.CURVE
-import org.kethereum.crypto.getAddress
+import org.kethereum.crypto.model.PublicKey
+import org.kethereum.crypto.toAddress
 import org.kethereum.encodings.decodeBase58
 import org.kethereum.extensions.toBytesPadded
 import org.kethereum.extensions.toHexStringZeroPadded
@@ -154,14 +155,14 @@ class JWTTools(
                 val pubKeyNoPrefix = recoveredPubKey
                         .toBytesPadded(65)
                         .copyOfRange(1, 65)
-                val recoveredAddress = getAddress(pubKeyNoPrefix).toNoPrefixHexString()
+                val recoveredAddress = PublicKey(pubKeyNoPrefix).toAddress().cleanHex
 
                 val numMatches = ddo.publicKey.map {
                     val pk = it.publicKeyHex?.hexToByteArray()
                             ?: it.publicKeyBase64?.decodeBase64()
                             ?: it.publicKeyBase58?.decodeBase58()
                             ?: byteArrayOf()
-                    (it.ethereumAddress ?: getAddress(pk).toHexString()).clean0xPrefix()
+                    (it.ethereumAddress?.clean0xPrefix() ?: PublicKey(pk).toAddress().cleanHex)
                 }.filter {
                     it == recoveredAddress
                 }.size

--- a/jwt/src/test/java/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/JWTToolsJVMTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class JWTToolsJVMTest {
 
@@ -23,16 +24,16 @@ class JWTToolsJVMTest {
     @Test
     fun verify() {
 
-        val latch = CountDownLatch(tokens.size)
-        tokens.forEach {
-            JWTTools().verify(it) { err, payload ->
-                assertNull(err)
+        tokens.forEachIndexed { index, token ->
+            val latch = CountDownLatch(tokens.size)
+            JWTTools().verify(token) { err, payload ->
+                assertNull("token $index failed verification", err)
                 println(payload)
                 latch.countDown()
             }
+            latch.await(15, TimeUnit.SECONDS)
         }
 
-        latch.await()
     }
 
     @Suppress("UNUSED_VARIABLE")

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     api "com.github.walleth.kethereum:crypto:$kethereum_version"
     api "com.github.walleth.kethereum:bip39:$kethereum_version"
+    api "com.github.walleth.kethereum:bip39_wordlist_en:$kethereum_version"
     api project(":core")
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"

--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -15,8 +15,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.kethereum.bip32.generateKey
-import org.kethereum.bip39.Mnemonic
+import org.kethereum.bip32.toKey
+import org.kethereum.bip39.model.MnemonicWords
+import org.kethereum.bip39.toSeed
 import org.kethereum.extensions.hexToBigInteger
 import org.spongycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
@@ -87,7 +88,7 @@ class HDSignerTests {
     @Test
     fun testJwtComponents() {
 
-        val referenceSeed = Mnemonic.mnemonicToSeed("vessel ladder alter error federal sibling chat ability sun glass valve picture")
+        val referenceSeed = MnemonicWords("vessel ladder alter error federal sibling chat ability sun glass valve picture").toSeed()
         val referencePayload = "Hello, world!".toByteArray()
 
         val referencePrivateKey = "65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960".hexToBigInteger()
@@ -95,9 +96,9 @@ class HDSignerTests {
         val referenceR = "6bcd81446183af193ca4a172d5c5c26345903b24770d90b5d790f74a9dec1f68".hexToBigInteger()
         val referenceS = "e2b85b3c92c9b4f3cf58de46e7997d8efb6e14b2e532d13dfa22ee02f3a43d5d".hexToBigInteger()
 
-        val derivedRootExtendedKey = generateKey(referenceSeed, UportHDSigner.UPORT_ROOT_DERIVATION_PATH)
+        val derivedRootExtendedKey = referenceSeed.toKey(UportHDSigner.UPORT_ROOT_DERIVATION_PATH)
 
-        assertEquals(referencePrivateKey, derivedRootExtendedKey.keyPair.privateKey)
+        assertEquals(referencePrivateKey, derivedRootExtendedKey.keyPair.privateKey.key)
 
         val keyPair = derivedRootExtendedKey.keyPair
 

--- a/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
@@ -11,8 +11,9 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.kethereum.crypto.ECKeyPair
+import org.kethereum.crypto.model.PrivateKey
 import org.kethereum.crypto.signMessage
+import org.kethereum.crypto.toECKeyPair
 import org.kethereum.extensions.hexToBigInteger
 import org.spongycastle.util.encoders.Hex
 import org.walleth.khex.hexToByteArray
@@ -125,7 +126,7 @@ class SignerTests {
     fun testPublicKey1() {
         val referencePrivateKey = "5047c789919e943c559d8c134091d47b4642122ba0111dfa842ef6edefb48f38"
         val referencePublicKey = "04bf42759e6d2a684ef64a8210c55bf2308e4101f78959ffa335ff045ef1e4252b1c09710281f8971b39efed7bfb61ae381ed73b9faa5a96f17e00c1a4c32796b1"
-        val keyPair = ECKeyPair.create(Hex.decode(referencePrivateKey))
+        val keyPair = PrivateKey(referencePrivateKey.hexToBigInteger()).toECKeyPair()
         val pubKeyBytes = keyPair.getUncompressedPublicKeyWithPrefix()
         val pubKeyHex = pubKeyBytes.toNoPrefixHexString()
 
@@ -159,7 +160,7 @@ class SignerTests {
 
     @Test
     fun testPublicKey2() {
-        val keypair = ECKeyPair.create(Hex.decode("278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f"))
+        val keypair = PrivateKey("278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f".hexToBigInteger()).toECKeyPair()
         val pubKeyBytes = keypair.getUncompressedPublicKeyWithPrefix()
         val pubKeyEnc = Hex.toHexString(pubKeyBytes)
         assertEquals("04fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea535847946393f8145252eea68afe67e287b3ed9b31685ba6c3b00060a73b9b1242d68f7", pubKeyEnc)
@@ -172,7 +173,7 @@ class SignerTests {
 
         val msg = "Hello, world!".toByteArray()
 
-        val keyPair = ECKeyPair.create(Hex.decode(referencePrivateKey))
+        val keyPair = PrivateKey(referencePrivateKey.hexToBigInteger()).toECKeyPair()
 
         val sigData = UportSigner().signJwt(msg, keyPair).getJoseEncoded()
 
@@ -186,7 +187,7 @@ class SignerTests {
 
         val msg = "Hello, world!".toByteArray()
 
-        val keyPair = ECKeyPair.create(Hex.decode(referencePrivateKey))
+        val keyPair = PrivateKey(referencePrivateKey.hexToBigInteger()).toECKeyPair()
 
         val sigData = UportSigner().signJwt(msg, keyPair).getDerEncoded()
 
@@ -202,7 +203,7 @@ class SignerTests {
 
         val msg = "Hello, world!".toByteArray()
 
-        val keyPair = ECKeyPair.create(referencePrivateKey)
+        val keyPair = PrivateKey(referencePrivateKey).toECKeyPair()
 
         val sigData = UportSigner().signJwt(msg, keyPair)
 
@@ -219,7 +220,7 @@ class SignerTests {
 
         val rawTransaction = "84CFC6Q7dACDL+/YlJ4gaMziLeTh6A8Vy3HvQ1ogo7N8iA3gtrOnZAAAiQq83vASNFZ4kA==".decodeBase64()
 
-        val keyPair = ECKeyPair.create(referencePrivKeyBytes)
+        val keyPair = PrivateKey(referencePrivKeyBytes).toECKeyPair()
 
         val sigData = keyPair.signMessage(rawTransaction)
 

--- a/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
@@ -10,13 +10,14 @@ import me.uport.sdk.core.toBase64
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.kethereum.bip39.Mnemonic
+import org.kethereum.bip39.generateMnemonic
+import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
 import java.security.SecureRandom
 import java.util.concurrent.CountDownLatch
 
 class UserInteractionContextTests {
 
-    private val phrase = Mnemonic.generateMnemonic()
+    private val phrase = generateMnemonic(wordList = WORDLIST_ENGLISH)
     private val key = ByteArray(32).apply { SecureRandom().nextBytes(this) }
 
     private val context = InstrumentationRegistry.getTargetContext()

--- a/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
@@ -5,8 +5,8 @@ import me.uport.sdk.core.decodeBase64
 import me.uport.sdk.core.padBase64
 import me.uport.sdk.core.toBase64
 import me.uport.sdk.core.toBase64UrlSafe
-import org.kethereum.crypto.ECKeyPair
-import org.kethereum.crypto.PRIVATE_KEY_SIZE
+import org.kethereum.crypto.model.ECKeyPair
+import org.kethereum.crypto.model.PRIVATE_KEY_SIZE
 import org.kethereum.extensions.toBytesPadded
 import org.kethereum.model.SignatureData
 import org.spongycastle.asn1.ASN1EncodableVector
@@ -78,7 +78,7 @@ fun unpackCiphertext(ciphertext: String): List<ByteArray> =
                 .map { it.decodeBase64() }
 
 fun ECKeyPair.getUncompressedPublicKeyWithPrefix(): ByteArray {
-    val pubBytes = this.publicKey.toBytesPadded(UportSigner.UNCOMPRESSED_PUBLIC_KEY_SIZE)
+    val pubBytes = this.publicKey.key.toBytesPadded(UportSigner.UNCOMPRESSED_PUBLIC_KEY_SIZE)
     pubBytes[0] = 0x04
     return pubBytes
 }

--- a/signer/src/main/java/com/uport/sdk/signer/KPSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/KPSigner.kt
@@ -1,9 +1,7 @@
 package com.uport.sdk.signer
 
-import org.kethereum.crypto.ECKeyPair
-import org.kethereum.crypto.getAddress
-import org.kethereum.crypto.signMessage
-import org.kethereum.crypto.signMessageHash
+import org.kethereum.crypto.*
+import org.kethereum.crypto.model.PrivateKey
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.hashes.sha256
 import org.kethereum.model.SignatureData
@@ -13,11 +11,12 @@ import org.kethereum.model.SignatureData
  *
  * There is no special handling of threads for callbacks.
  */
-class KPSigner(private val privateKey: String) : Signer {
+class KPSigner(privateKey: String) : Signer {
+
+    private val keyPair = PrivateKey(privateKey.hexToBigInteger()).toECKeyPair()
 
     override fun signJWT(rawPayload: ByteArray, callback: (err: Exception?, sigData: SignatureData) -> Unit) {
         try {
-            val keyPair = ECKeyPair.create(privateKey.hexToBigInteger())
             val sigData = signMessageHash(rawPayload.sha256(), keyPair, false)
             callback(null, sigData)
         } catch (err: Exception) {
@@ -25,12 +24,11 @@ class KPSigner(private val privateKey: String) : Signer {
         }
     }
 
-    override fun getAddress() = ECKeyPair.create(privateKey.hexToBigInteger()).getAddress()
+    override fun getAddress() = keyPair.toAddress().hex
 
     override fun signETH(rawMessage: ByteArray, callback: (err: Exception?, sigData: SignatureData) -> Unit) {
 
         try {
-            val keyPair = ECKeyPair.create(privateKey.hexToBigInteger())
             val sigData = keyPair.signMessage(rawMessage)
             callback(null, sigData)
         } catch (ex: Exception) {

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -6,12 +6,15 @@ import com.uport.sdk.signer.encryption.KeyProtection
 import me.uport.sdk.core.decodeBase64
 import me.uport.sdk.core.padBase64
 import me.uport.sdk.core.toBase64
-import org.kethereum.bip32.generateKey
-import org.kethereum.bip39.Mnemonic
-import org.kethereum.crypto.getAddress
+import org.kethereum.bip39.entropyToMnemonic
+import org.kethereum.bip39.mnemonicToEntropy
+import org.kethereum.bip39.model.MnemonicWords
+import org.kethereum.bip39.toKey
+import org.kethereum.bip39.validate
+import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
 import org.kethereum.crypto.signMessage
+import org.kethereum.crypto.toAddress
 import org.kethereum.model.SignatureData
-import org.walleth.khex.prepend0xPrefix
 import java.security.SecureRandom
 
 @Suppress("unused", "KDocUnresolvedReference")
@@ -41,7 +44,7 @@ class UportHDSigner : UportSigner() {
         val entropyBuffer = ByteArray(128 / 8)
         SecureRandom().nextBytes(entropyBuffer)
 
-        val seedPhrase = Mnemonic.entropyToMnemonic(entropyBuffer)
+        val seedPhrase = entropyToMnemonic(entropyBuffer, WORDLIST_ENGLISH)
 
         return importHDSeed(context, level, seedPhrase, callback)
 
@@ -60,17 +63,17 @@ class UportHDSigner : UportSigner() {
     fun importHDSeed(context: Context, level: KeyProtection.Level, phrase: String, callback: (err: Exception?, address: String, pubKey: String) -> Unit) {
 
         try {
-            val seedBuffer = Mnemonic.mnemonicToSeed(phrase)
+//            val seedBuffer = mnemonicToSeed(phrase)
 
-            val entropyBuffer = Mnemonic.mnemonicToEntropy(phrase)
+            val entropyBuffer = mnemonicToEntropy(phrase, WORDLIST_ENGLISH)
 
-            val extendedRootKey = generateKey(seedBuffer, UPORT_ROOT_DERIVATION_PATH)
+            val extendedRootKey = MnemonicWords(phrase).toKey(UPORT_ROOT_DERIVATION_PATH)
 
             val keyPair = extendedRootKey.keyPair
 
             val publicKeyBytes = keyPair.getUncompressedPublicKeyWithPrefix()
             val publicKeyString = publicKeyBytes.toBase64().padBase64()
-            val address: String = keyPair.getAddress().prepend0xPrefix()
+            val address: String = keyPair.toAddress().hex
 
             val label = asSeedLabel(address)
 
@@ -142,9 +145,8 @@ class UportHDSigner : UportSigner() {
 
             try {
 
-                val phrase = Mnemonic.entropyToMnemonic(entropyBuff)
-                val seed = Mnemonic.mnemonicToSeed(phrase)
-                val extendedKey = generateKey(seed, derivationPath)
+                val phrase = entropyToMnemonic(entropyBuff, WORDLIST_ENGLISH)
+                val extendedKey = MnemonicWords(phrase).toKey(derivationPath)
 
                 val keyPair = extendedKey.keyPair
 
@@ -192,9 +194,8 @@ class UportHDSigner : UportSigner() {
             }
 
             try {
-                val phrase = Mnemonic.entropyToMnemonic(entropyBuff)
-                val seed = Mnemonic.mnemonicToSeed(phrase)
-                val extendedKey = generateKey(seed, derivationPath)
+                val phrase = entropyToMnemonic(entropyBuff, WORDLIST_ENGLISH)
+                val extendedKey = MnemonicWords(phrase).toKey(derivationPath)
 
                 val keyPair = extendedKey.keyPair
 
@@ -230,15 +231,14 @@ class UportHDSigner : UportSigner() {
             }
 
             try {
-                val phrase = Mnemonic.entropyToMnemonic(entropyBuff)
-                val seed = Mnemonic.mnemonicToSeed(phrase)
-                val extendedKey = generateKey(seed, derivationPath)
+                val phrase = entropyToMnemonic(entropyBuff, WORDLIST_ENGLISH)
+                val extendedKey = MnemonicWords(phrase).toKey(derivationPath)
 
                 val keyPair = extendedKey.keyPair
 
                 val publicKeyBytes = keyPair.getUncompressedPublicKeyWithPrefix()
                 val publicKeyString = publicKeyBytes.toBase64().padBase64()
-                val address: String = keyPair.getAddress().prepend0xPrefix()
+                val address: String = keyPair.toAddress().hex
 
                 return@decrypt callback(null, address, publicKeyString)
 
@@ -271,7 +271,7 @@ class UportHDSigner : UportSigner() {
             }
 
             try {
-                val phrase = Mnemonic.entropyToMnemonic(entropyBuff)
+                val phrase = entropyToMnemonic(entropyBuff, WORDLIST_ENGLISH)
                 return@decrypt callback(null, phrase)
             } catch (exception: Exception) {
                 return@decrypt callback(err, "")
@@ -282,7 +282,7 @@ class UportHDSigner : UportSigner() {
     /**
      * Verifies if a given phrase is a valid mnemonic phrase usable in seed generation
      */
-    fun validateMnemonic(phrase: String): Boolean = Mnemonic.validateMnemonic(phrase)
+    fun validateMnemonic(phrase: String): Boolean = MnemonicWords(phrase).validate(WORDLIST_ENGLISH)
 
     /**
      * Returns a list of addresses representing the uport roots used as handles for seeds

--- a/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/DerivationTest.kt
+++ b/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/DerivationTest.kt
@@ -2,8 +2,10 @@ package com.uport.sdk.signer.crypto.bip32
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.kethereum.bip32.ExtendedKey
-import org.kethereum.bip32.generateKey
+import org.kethereum.bip32.model.Seed
+import org.kethereum.bip32.model.XPriv
+import org.kethereum.bip32.toExtendedKey
+import org.kethereum.bip32.toKey
 import org.walleth.khex.hexToByteArray
 
 class DerivationTest {
@@ -14,7 +16,7 @@ class DerivationTest {
 
         testData.forEach {
 
-            val derivedKey = generateKey(it.seed.hexToByteArray(), it.path)
+            val derivedKey = Seed(it.seed.hexToByteArray()).toKey(it.path)
 
             val obtainedPub = derivedKey.asPublicOnly().serialize()
             assertEquals(it.expectedPublicKey, obtainedPub)
@@ -22,8 +24,8 @@ class DerivationTest {
             val obtainedPrv = derivedKey.serialize()
             assertEquals(it.expectedPrivateKey, obtainedPrv)
 
-            assertEquals(ExtendedKey.parse(it.expectedPublicKey), derivedKey.asPublicOnly())
-            assertEquals(ExtendedKey.parse(it.expectedPrivateKey), derivedKey)
+            assertEquals(XPriv(it.expectedPublicKey).toExtendedKey(), derivedKey.asPublicOnly())
+            assertEquals(XPriv(it.expectedPrivateKey).toExtendedKey(), derivedKey)
 
             counter++
 


### PR DESCRIPTION
### What's here

This is a long overdue update of a bunch of dependencies, most importantly of kethereum.
The key derivation API and handling of mnemonic phrases has changed in kethereum, requiring a review of several classes and tests.

The `signer` module has the most changes since it dealt most with this API.

### Testing

The whole battery of tests should be run.
Use `./gradlew clean test cC` with at least one emulator/device connected.

None of the test data has changed so this should reflect identical functionality.