### PR TITLE
[bugfix] recovery param jose encoding

### DIFF
--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
@@ -22,7 +22,7 @@ class EthrDID(
         private val address: String,
         private val rpc: JsonRPC,
         private val registry: String,
-        var signer: Signer
+        val signer: Signer
 ) {
 
     private val owner: String? = null

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTSignerAlgorithmRuntimeTest.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTSignerAlgorithmRuntimeTest.kt
@@ -60,7 +60,7 @@ class JWTSignerAlgorithmRuntimeTest {
 
         val signature = JWTSignerAlgorithm(ES256K_R).sign(referencePayload, testedSigner)
 
-        val expectedSignature = "a82BRGGDrxk8pKFy1cXCY0WQOyR3DZC115D3Sp3sH2jiuFs8ksm0889Y3kbnmX2O-24UsuUy0T36Iu4C86Q9XRw"
+        val expectedSignature = "a82BRGGDrxk8pKFy1cXCY0WQOyR3DZC115D3Sp3sH2jiuFs8ksm0889Y3kbnmX2O-24UsuUy0T36Iu4C86Q9XQE"
         assertEquals(expectedSignature, signature)
         assertEquals(65, signature.decodeBase64().size)
     }

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -119,7 +119,7 @@ class JWTToolsTests {
         val issuerDID = "did:ethr:${signer.getAddress()}"
 
         val jwt = tested.createJWT(payload, issuerDID, signer)
-        val expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjbGFpbXMiOnsibmFtZSI6IlIgRGFuZWVsIE9saXZhdyJ9LCJpYXQiOjEyMzQ1Njc4LCJleHAiOjEyMzQ1OTc4LCJpc3MiOiJkaWQ6ZXRocjoweDQxMjNjYmQxNDNiNTVjMDZlNDUxZmYyNTNhZjA5Mjg2YjY4N2E5NTAifQ.o6eDKYjHJnak1ylkpe9g8krxvK9UEhKf-1T0EYhH8pGyb8MjOEepRJi8DYlVEnZno0DkVYXQCf3u1i_HThBKtBs"
+        val expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjbGFpbXMiOnsibmFtZSI6IlIgRGFuZWVsIE9saXZhdyJ9LCJpYXQiOjEyMzQ1Njc4LCJleHAiOjEyMzQ1OTc4LCJpc3MiOiJkaWQ6ZXRocjoweDQxMjNjYmQxNDNiNTVjMDZlNDUxZmYyNTNhZjA5Mjg2YjY4N2E5NTAifQ.o6eDKYjHJnak1ylkpe9g8krxvK9UEhKf-1T0EYhH8pGyb8MjOEepRJi8DYlVEnZno0DkVYXQCf3u1i_HThBKtAA"
         assertEquals(expected, jwt)
         val tt = tested.decode(expected)
         assertEquals(12345678L, tt.second.iat)

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTSignerAlgorithmTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTSignerAlgorithmTest.kt
@@ -28,7 +28,7 @@ class JWTSignerAlgorithmTest {
 
         val signer = KPSigner("65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960")
 
-        val expectedSignature = "a82BRGGDrxk8pKFy1cXCY0WQOyR3DZC115D3Sp3sH2jiuFs8ksm0889Y3kbnmX2O-24UsuUy0T36Iu4C86Q9XRw"
+        val expectedSignature = "a82BRGGDrxk8pKFy1cXCY0WQOyR3DZC115D3Sp3sH2jiuFs8ksm0889Y3kbnmX2O-24UsuUy0T36Iu4C86Q9XQE"
         val signature = JWTSignerAlgorithm(ES256K_R).sign("Hello, world!", signer)
 
         assertEquals(expectedSignature, signature)

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTSignerAlgorithmTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTSignerAlgorithmTest.kt
@@ -35,4 +35,18 @@ class JWTSignerAlgorithmTest {
         assertEquals(65, signature.decodeBase64().size)
 
     }
+
+    @Test
+    fun `can sign using vector from did-jwt`() = runBlocking {
+
+        val signer = KPSigner("278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f")
+
+        //the signature data from https://github.com/uport-project/did-jwt/blob/develop/src/__tests__/__snapshots__/SimpleSigner-test.js.snap
+        // JOSE encoded with recovery param
+        val expectedSignature = "jsvdLwqr-O206hkegoq6pbo7LJjCaflEKHCvfohBP9XJ4C7mG2TPL9YjyKEpYSXqqkUrfRoCxQecHR11Uh7POwA"
+
+        val signature = JWTSignerAlgorithm(ES256K_R).sign("thequickbrownfoxjumpedoverthelazyprogrammer", signer)
+
+        assertEquals(expectedSignature, signature)
+    }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     api project(":universal-did")
     api project(":ethr-did")
     api project(":uport-did")
+    api project(":credentials")
+    api project(":transport")
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_runner_version"

--- a/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
@@ -24,6 +24,9 @@ const val SIG_RECOVERABLE_SIZE = SIG_SIZE + 1
 
 /**
  * Returns the JOSE encoding of the standard signature components (joined by empty string)
+ *
+ * @param recoverable If this is true then the buffer returned gets an extra byte with the
+ *          recovery param shifted back to [0, 1] ( as opposed to [27,28] )
  */
 fun SignatureData.getJoseEncoded(recoverable: Boolean = false): String {
     val size = if (recoverable)
@@ -35,7 +38,7 @@ fun SignatureData.getJoseEncoded(recoverable: Boolean = false): String {
     bos.write(this.r.toBytesPadded(SIG_COMPONENT_SIZE))
     bos.write(this.s.toBytesPadded(SIG_COMPONENT_SIZE))
     if (recoverable) {
-        bos.write(byteArrayOf(this.v))
+        bos.write(byteArrayOf((this.v - 27).toByte()))
     }
     return bos.toByteArray().toBase64UrlSafe()
 }

--- a/transport/src/androidTest/AndroidManifest.xml
+++ b/transport/src/androidTest/AndroidManifest.xml
@@ -3,6 +3,6 @@
 
     <!-- manifest only used for testing -->
     <application>
-        <activity android:name=".IntentSenderAndroidTest$DummyActivity" />
+        <activity android:name=".TransportsAndroidTests$DummyActivity" />
     </application>
 </manifest>

--- a/transport/src/main/java/me/uport/sdk/transport/Transports.kt
+++ b/transport/src/main/java/me/uport/sdk/transport/Transports.kt
@@ -20,6 +20,7 @@ class Transports {
         val uri = Uri.parse("https://id.uport.me/req/$encodedQuery")
         val intent = Intent(Intent.ACTION_VIEW, uri)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
+        println(uri.toString())
         context.startActivity(intent)
     }
 


### PR DESCRIPTION
### What's here

This fixes #42
This fixes [#161565476] from pivotal.

The recovery parameter of a `SignatureData` is either 27 or 28 but when it is used to recover public keys from signatures it should be 0 or 1.
JWTs created by this SDK should be verifiable across platforms, including [did-jwt] (https://github.com/uport-project/did-jwt)
For this reason, the recovery param has to be encoded as 0 or 1 in the buffer representing the signature of JWTs

The key part of this changeset is in `Extensions.kt`, all the other changes involve tests and test data that needs to be adapted to the new format.

### Testing

A test was added to check for this scenario.
Running it in commit [b69eb9c](https://github.com/uport-project/uport-android-sdk/commit/b69eb9c7df27ab1ac852f39e64ce27c572b7d2bd) should fail.

To run the entire battery of tests, use `./gradlew clean test cC` with a device connected. It takes 2-3 minutes.

### Note

This does not affect the other uses of the signer (like the uPort mobile app) because the signature data is transferred using  individual components, not as a JOSE encoding.