### PR TITLE
[support] fix warnings in ProtectedSharedPreferences

### DIFF
--- a/signer/src/main/java/com/uport/sdk/signer/storage/ProtectedSharedPreferences.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/storage/ProtectedSharedPreferences.kt
@@ -67,10 +67,10 @@ class ProtectedSharedPreferences(
     private fun canDecrypt(queryKey: String): Boolean {
         return try {
             if (queryKey.matches("^e:.*".toRegex())) {
-                val set = delegate.getStringSet(queryKey, mutableSetOf(/*nothing*/))
+                val set = delegate.getStringSet(queryKey, mutableSetOf(/*nothing*/)).orEmpty()
                 set.forEach { crypto.decrypt(it) }
             } else {
-                crypto.decrypt(delegate.getString(queryKey, ""))
+                crypto.decrypt(delegate.getString(queryKey, "") ?: "")
             }
             true
         } catch (ex: Exception) {
@@ -89,7 +89,7 @@ class ProtectedSharedPreferences(
         }
 
         val decryptedBytes = try {
-            crypto.decrypt(delegate.getString(queryKey, ""))
+            crypto.decrypt(delegate.getString(queryKey, "") ?: "")
         } catch (ex: Exception) {
             delegate.edit().remove(queryKey).apply()
             return default
@@ -106,7 +106,7 @@ class ProtectedSharedPreferences(
             return default
         }
         val decryptedBytes = try {
-            crypto.decrypt(delegate.getString(queryKey, ""))
+            crypto.decrypt(delegate.getString(queryKey, "") ?: "")
         } catch (ex: Exception) {
             delegate.edit().remove(queryKey).apply()
             return default
@@ -123,7 +123,7 @@ class ProtectedSharedPreferences(
         }
 
         val decryptedBytes = try {
-            crypto.decrypt(delegate.getString(queryKey, ""))
+            crypto.decrypt(delegate.getString(queryKey, "") ?: "")
         } catch (ex: Exception) {
             delegate.edit().remove(queryKey).apply()
             return default
@@ -140,7 +140,7 @@ class ProtectedSharedPreferences(
         }
 
         val decryptedBytes = try {
-            crypto.decrypt(delegate.getString(queryKey, ""))
+            crypto.decrypt(delegate.getString(queryKey, "") ?: "")
         } catch (ex: Exception) {
             delegate.edit().remove(queryKey).apply()
             return default
@@ -157,7 +157,7 @@ class ProtectedSharedPreferences(
         }
 
         val decryptedBytes = try {
-            crypto.decrypt(delegate.getString(queryKey, ""))
+            crypto.decrypt(delegate.getString(queryKey, "") ?: "")
         } catch (ex: Exception) {
             delegate.edit().remove(queryKey).apply()
             return default


### PR DESCRIPTION
### What's here

This is a fix for some of the warnings thrown during build.
No functionality change, just telling kotlin that defaults are non-null.

### Testing
`./gradlew test cC` with an emulator connected

### Note
Some warnings are still showing but will disappear after #37 is fixed