### PR TITLE
[Bugfix] 162137904 jwt signature recovery

### DIFF
--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -224,7 +224,7 @@ class JWTTools(
     }
 
     /***
-     * Adapted from Kethereum
+     * Copied from Kethereum because it is a private method there
      */
     private fun recoverFromSignature(recId: Int, sig: ECDSASignature, message: ByteArray?): BigInteger? {
         require(recId >= 0) { "recId must be positive" }
@@ -281,7 +281,7 @@ class JWTTools(
 
         val qBytes = q.getEncoded(false)
         // We remove the prefix
-        return BigInteger(1, qBytes)//Arrays.copyOfRange(qBytes, 0, qBytes.size))
+        return BigInteger(1, qBytes.copyOfRange(1, qBytes.size))
     }
 
     /**

--- a/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
@@ -1,0 +1,38 @@
+package me.uport.sdk.jwt
+
+import com.uport.sdk.signer.KPSigner
+import com.uport.sdk.signer.signJWT
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.kethereum.crypto.model.PrivateKey
+import org.kethereum.crypto.publicKeyFromPrivate
+import org.kethereum.extensions.hexToBigInteger
+import org.kethereum.extensions.toHexStringNoPrefix
+import org.kethereum.hashes.sha256
+import org.walleth.khex.toHexString
+
+class KeyRecoveryTest {
+
+    //  Uncomment `@Test` to iterate over 1000 * 1000 key/message combinations. Takes a lot of time.
+    //@Test
+    fun `can recover key from JWT signature`() = runBlocking {
+        val tools = JWTTools()
+
+        for (i in 0 until 1000) {
+            val privateKey = "super secret $i".toByteArray().sha256().toHexString()
+            val pubKey = publicKeyFromPrivate(PrivateKey(privateKey.hexToBigInteger())).key.toHexStringNoPrefix()
+            val signer = KPSigner(privateKey)
+            println("trying key $i on 1000 messages")
+            for (j in 0 until 1000) {
+                val message = "hello $i".toByteArray(Charsets.UTF_8)
+
+                val sigData = signer.signJWT(message)
+
+                val recovered = tools.signedJwtToKey(message, sigData).toHexStringNoPrefix()
+
+                assertEquals("failed at key $i, message $j", pubKey, recovered)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### What's here

I added a test to do a lot of signJWT calls and recover the public keys from the signatures.
The test goes through 1000000 combinations of keys and messages.

I found no combination that produces bad signatures so I commented out the test because it takes 15-20 minutes at least but left it there for sanity checks.

This closes [#162137904](https://www.pivotaltracker.com/story/show/162137904) on pivotal.

### Testing

uncomment line 17 in `KeyRecoveryTest.kt` and run it in android studio or with `./gradlew :jwt:testDebug` to see it in action