### PR TITLE
[Feature] parse selective disclosure response uri

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ buildscript {
         espresso_version = "3.0.2"
         junit_version = "4.12"
         mockito_version = "2.23.0"
-        mockito_kotlin_version = "2.0.0-RC3"
+        mockito_kotlin_version = "2.0.0"
+        robolectric_version = "4.1"
 
         moshi_version = "1.7.0"
         okhttp_version = "3.10.0"

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -1,10 +1,10 @@
 package me.uport.sdk.demoapp
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_deep_link.*
+import me.uport.sdk.transport.ResponseParser
 
 class DeepLinkActivity : AppCompatActivity() {
 
@@ -19,14 +19,13 @@ class DeepLinkActivity : AppCompatActivity() {
         handleIntent(intent)
     }
 
-    private fun handleIntent(intent: Intent) {
-        val appLinkAction = intent.action
-        val appLinkData: Uri? = intent.data
-        if (Intent.ACTION_VIEW == appLinkAction) {
-            appLinkData?.also { link ->
-                println("got called with: $link")
-                Toast.makeText(this, link.toString(), Toast.LENGTH_LONG).show()
-            } ?: Toast.makeText(this, "no data to parse in intent", Toast.LENGTH_SHORT).show()
+    private fun handleIntent(intent: Intent?) {
+        val token = ResponseParser.extractTokenFromIntent(intent)
+        val text = if (token == null) {
+            "nothing can be extracted from the intent:\n${intent?.data}"
+        } else {
+            "The response we got back from uPort is:\n$token"
         }
+        deep_link_token.text = text
     }
 }

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -20,11 +20,11 @@ class DeepLinkActivity : AppCompatActivity() {
     }
 
     private fun handleIntent(intent: Intent?) {
-        val token = ResponseParser.extractTokenFromIntent(intent)
-        val text = if (token == null) {
-            "nothing can be extracted from the intent:\n${intent?.data}"
-        } else {
+        val text = try {
+            val token = ResponseParser.extractTokenFromIntent(intent)
             "The response we got back from uPort is:\n$token"
+        } catch (exception: RuntimeException) {
+            "we got an error:\n${exception.message}"
         }
         deep_link_token.text = text
     }

--- a/demoapp/src/main/res/layout/activity_deep_link.xml
+++ b/demoapp/src/main/res/layout/activity_deep_link.xml
@@ -7,10 +7,11 @@
     tools:context=".DeepLinkActivity">
 
     <TextView
+        android:id="@+id/deep_link_token"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:text="deep link activity"
+        tools:text="deep link token result"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -178,7 +178,7 @@ class JWTTools(
 
         // extract recoveryByte if available or generate a new one
         val recoveryBytes = if (signatureBytes.size > 64)
-            signatureBytes.sliceArray(64..64) // an array of just the recovery byte
+            byteArrayOf(signatureBytes[64])
         else
             byteArrayOf(27, 28) //try all recovery options
 

--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -27,6 +27,12 @@ android {
         }
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
 }
 
 dependencies {
@@ -41,6 +47,7 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.mockito:mockito-inline:$mockito_version"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
+    testImplementation "org.robolectric:robolectric:$robolectric_version"
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_rules_version"

--- a/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
+++ b/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
@@ -1,0 +1,49 @@
+package me.uport.sdk.transport
+
+import android.content.Intent
+import android.net.Uri
+import java.net.URI
+
+/**
+ * This class should be used when receiving a deeplink callback
+ * It contains helpers for interpreting responses
+ */
+object ResponseParser {
+
+    //language=RegExp
+    private val fragmentMatcher = ".*[&#]*(access_token=([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+))&*.*$".toRegex()
+
+    /**
+     * Given a deep link uri, this method tries to extract a JWT response from it.
+     * @param redirectUrl the deeplink URI
+     * @return a JWT token string if one could be extracted or `null` otherwise
+     */
+    fun extractTokenFromRedirectUri(redirectUrl: String): String? {
+        val uriFragment = try {
+            URI.create(redirectUrl).fragment
+        } catch (ex: Exception) {
+            null
+        } ?: return null
+
+        val matchResult = fragmentMatcher.matchEntire(uriFragment) ?: return null
+        val (_, token) = matchResult.destructured
+        return token
+    }
+
+    /**
+     * Given an intent, this method tries to extract a JWT response from the intent data.
+     * @param intent the intent received through a deep-link
+     * @return a JWT token string if one could be extracted or `null` otherwise
+     */
+    fun extractTokenFromIntent(intent: Intent?): String? {
+        intent ?: return null
+
+        val appLinkAction = intent.action ?: return null
+        val appLinkData: Uri? = intent.data ?: return null
+        if (appLinkAction == Intent.ACTION_VIEW) {
+            return extractTokenFromRedirectUri(appLinkData.toString())
+        }
+        return null
+    }
+
+}

--- a/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
+++ b/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
@@ -13,37 +13,62 @@ object ResponseParser {
     //language=RegExp
     private val fragmentMatcher = ".*[&#]*(access_token=([A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+))&*.*$".toRegex()
 
+    //language=RegExp
+    private val errorMatcher = ".*[&#]*(error=(.*))&*.*$".toRegex()
+
     /**
      * Given a deep link uri, this method tries to extract a JWT response from it.
-     * @param redirectUrl the deeplink URI
+     * The expected format is a string of the form "access_token=<JWT>" appended to the `fragment`
+     * part of a URI
+     *
+     * @param deeplinkURI the deeplink URI
      * @return a JWT token string if one could be extracted or `null` otherwise
+     *
+     * @throws IllegalArgumentException if the URI can't be parsed or does not match the expected format
+     * @throws RuntimeException if the deeplink has an error block in the fragment
      */
-    fun extractTokenFromRedirectUri(redirectUrl: String): String? {
+    fun extractTokenFromRedirectUri(deeplinkURI: String): String? {
         val uriFragment = try {
-            URI.create(redirectUrl).fragment
+            URI.create(deeplinkURI).fragment
         } catch (ex: Exception) {
             null
-        } ?: return null
+        } ?: throw IllegalArgumentException("Cannot parse URI")
 
-        val matchResult = fragmentMatcher.matchEntire(uriFragment) ?: return null
+        errorMatcher.matchEntire(uriFragment)?.let {
+            val (_, errorMessage) = it.destructured
+            throw RuntimeException(errorMessage)
+        }
+
+        val matchResult = fragmentMatcher.matchEntire(uriFragment)
+                ?: throw IllegalArgumentException("URI does not match known response format")
         val (_, token) = matchResult.destructured
+
         return token
     }
 
     /**
      * Given an intent, this method tries to extract a JWT response from the intent data.
+     * The expected format is a string of the form "access_token=<JWT>" appended to the `fragment`
+     * part of the data URI
      * @param intent the intent received through a deep-link
      * @return a JWT token string if one could be extracted or `null` otherwise
+     *
+     * @throws IllegalArgumentException if the intent has no data
+     *              or the action does not match [Intent.ACTION_VIEW]
+     *              or the URI does not match the expected format
+     * @throws RuntimeException if the data URI has an error block in the fragment part
      */
     fun extractTokenFromIntent(intent: Intent?): String? {
-        intent ?: return null
+        intent ?: throw IllegalArgumentException("Can't process a null intent")
 
-        val appLinkAction = intent.action ?: return null
-        val appLinkData: Uri? = intent.data ?: return null
-        if (appLinkAction == Intent.ACTION_VIEW) {
+        val appLinkData: Uri? = intent.data
+                ?: throw IllegalArgumentException("Can't process an intent with no data")
+
+        if (Intent.ACTION_VIEW == intent.action) {
             return extractTokenFromRedirectUri(appLinkData.toString())
+        } else {
+            throw IllegalArgumentException("Intent action has to be ${Intent.ACTION_VIEW}")
         }
-        return null
     }
 
 }

--- a/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
+++ b/transport/src/main/java/me/uport/sdk/transport/ResponseParser.kt
@@ -7,6 +7,9 @@ import java.net.URI
 /**
  * This class should be used when receiving a deeplink callback
  * It contains helpers for interpreting responses
+ *
+ * API volatility: __high__
+ *
  */
 object ResponseParser {
 

--- a/transport/src/test/java/me/uport/sdk/transport/IntentParserTest.kt
+++ b/transport/src/test/java/me/uport/sdk/transport/IntentParserTest.kt
@@ -1,0 +1,40 @@
+package me.uport.sdk.transport
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IntentParserTest {
+
+    @Test
+    fun `extracts token from simple intent`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myapp:my-dapp.com#access_token=header.payload.signature"))
+        val token = ResponseParser.extractTokenFromIntent(intent)
+        Assert.assertEquals("header.payload.signature", token)
+    }
+
+    @Test
+    fun `rejects wrong action`() {
+        val intent = Intent("view my intent", Uri.parse("myapp:my-dapp.com#access_token=header.payload.signature"))
+        val token = ResponseParser.extractTokenFromIntent(intent)
+        Assert.assertNull(token)
+    }
+
+    @Test
+    fun `rejects null intent`() {
+        val token = ResponseParser.extractTokenFromIntent(null)
+        Assert.assertNull(token)
+    }
+
+    @Test
+    fun `rejects malformed uri`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("access_token=header.payload.signature"))
+        val token = ResponseParser.extractTokenFromIntent(intent)
+        Assert.assertNull(token)
+    }
+
+}

--- a/transport/src/test/java/me/uport/sdk/transport/IntentParserTest.kt
+++ b/transport/src/test/java/me/uport/sdk/transport/IntentParserTest.kt
@@ -3,12 +3,17 @@ package me.uport.sdk.transport
 import android.content.Intent
 import android.net.Uri
 import org.junit.Assert
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class IntentParserTest {
+
+    @get:Rule
+    val expectedExceptionRule: ExpectedException = ExpectedException.none()
 
     @Test
     fun `extracts token from simple intent`() {
@@ -18,21 +23,41 @@ class IntentParserTest {
     }
 
     @Test
+    fun `reject null intent`() {
+        expectedExceptionRule.expect(IllegalArgumentException::class.java)
+        val token = ResponseParser.extractTokenFromIntent(null)
+        Assert.assertNull(token)
+    }
+
+    @Test
+    fun `reject null data`() {
+        expectedExceptionRule.expect(IllegalArgumentException::class.java)
+        val token = ResponseParser.extractTokenFromIntent(Intent(Intent.ACTION_VIEW, null))
+        Assert.assertNull(token)
+    }
+
+
+    @Test
     fun `rejects wrong action`() {
+        expectedExceptionRule.expect(IllegalArgumentException::class.java)
         val intent = Intent("view my intent", Uri.parse("myapp:my-dapp.com#access_token=header.payload.signature"))
         val token = ResponseParser.extractTokenFromIntent(intent)
         Assert.assertNull(token)
     }
 
     @Test
-    fun `rejects null intent`() {
-        val token = ResponseParser.extractTokenFromIntent(null)
+    fun `rejects malformed uri`() {
+        expectedExceptionRule.expect(IllegalArgumentException::class.java)
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("access_token=header.payload.signature"))
+        val token = ResponseParser.extractTokenFromIntent(intent)
         Assert.assertNull(token)
     }
 
     @Test
-    fun `rejects malformed uri`() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("access_token=header.payload.signature"))
+    fun `rejects with correct error message`() {
+        expectedExceptionRule.expect(RuntimeException::class.java)
+        expectedExceptionRule.expectMessage("access_denied")
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myapp:my-dapp.com#error=access_denied"))
         val token = ResponseParser.extractTokenFromIntent(intent)
         Assert.assertNull(token)
     }

--- a/transport/src/test/java/me/uport/sdk/transport/ResponseParserTest.kt
+++ b/transport/src/test/java/me/uport/sdk/transport/ResponseParserTest.kt
@@ -2,7 +2,9 @@ package me.uport.sdk.transport
 
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 class ResponseParserTest {
 
@@ -43,12 +45,16 @@ class ResponseParserTest {
         }
     }
 
+    @get:Rule
+    val expectedExceptionRule: ExpectedException = ExpectedException.none()
+
     @Test
     fun `reject invalid URIs`() {
         invalid.forEach { redirect ->
+            expectedExceptionRule.expect(IllegalArgumentException::class.java)
+            expectedExceptionRule.expectMessage("Cannot parse URI")
             val token = ResponseParser.extractTokenFromRedirectUri(redirect)
             assertNull("expected parsing to fail at url: $redirect", token)
         }
     }
-
 }

--- a/transport/src/test/java/me/uport/sdk/transport/ResponseParserTest.kt
+++ b/transport/src/test/java/me/uport/sdk/transport/ResponseParserTest.kt
@@ -1,0 +1,54 @@
+package me.uport.sdk.transport
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ResponseParserTest {
+
+    private val valid = listOf(
+            "https://example.com#access_token=header.payload.signature",
+            "https://example.com#access_token=header.payload.signature&something=else",
+            "https://example.com#something=else&access_token=header.payload.signature",
+            "https://example.com?something=else#access_token=header.payload.signature",
+            "https://example.com/some/path?something=else#access_token=header.payload.signature",
+            "https://uport-project.github.io/uport-android-sdk#access_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NDUxNDgzOTQsImV4cCI6MTU0NTIzNDc5NCwiYXVkIjoiZGlkOmV0aHI6MHhjZjAzZGQwYTg5NGVmNzljYjViNjAxYTQzYzRiMjVlM2FlNGM2N2VkIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvazFBV1F2QXZuMlluSzhCVDlRWnNVNk1TUVpKWEx5eTNLIiwib3duIjp7Im5hbWUiOiJHaWdlbCBEZWMgMTgifSwicmVxIjoiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOa3N0VWlKOS5leUpqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2ZFhCdmNuUXRjSEp2YW1WamRDNW5hWFJvZFdJdWFXOHZkWEJ2Y25RdFlXNWtjbTlwWkMxelpHc2lMQ0p5WlhGMVpYTjBaV1FpT2xzaWJtRnRaU0lzSW1OdmRXNTBjbmtpWFN3aVlXTjBJam9pWjJWdVpYSmhiQ0lzSW5SNWNHVWlPaUp6YUdGeVpWSmxjU0lzSW1saGRDSTZNVFUwTlRFME9ETTNPQ3dpWlhod0lqb3hOVFExTVRRNE9UYzRMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR05tTUROa1pEQmhPRGswWldZM09XTmlOV0kyTURGaE5ETmpOR0l5TldVellXVTBZelkzWldRaWZRLjFUVjVnM21XTlRMMy03Q2lBdDM0X2V5TjlGOFJGZzZRejBMZlJwTzhkeHFMYzVmV0E3NDRwdEFmbWhOWGdvbmc5WTBCaFJpVTd4T2s1N1VYOVZkckVnQSIsImlzcyI6ImRpZDpldGhyOjB4ZjMwYzBjMjc5YTYyODlmNzBmZjZkZGJkMmQ0MmU1MWRkOTZiMTk2YSJ9._OGoEc-xefBq88A10J6An2PaNpdhsveg793lp3Br1yX7-w46e7w7y9vLKGbN32XsJGqJ7t_fy81kG04jMXCCFgE",
+            "myapp:my-dapp.com#access_token=header.payload.signature",
+            "myapp:my-dapp.com#access_token=header.payload.signature&something=else",
+            "myapp:my-dapp.com#something=else&access_token=header.payload.signature",
+            "myapp:my-dapp.com?something=else#access_token=header.payload.signature",
+            "myapp:my-dapp.com/some/path?something=else#access_token=header.payload.signature",
+            "my.app://my-dapp.com#access_token=header.payload.signature",
+            "my.app://my-dapp.com#access_token=header.payload.signature&something=else",
+            "my.app://my-dapp.com#something=else&access_token=header.payload.signature",
+            "my.app://my-dapp.com?something=else#access_token=header.payload.signature",
+            "my.app://my-dapp.com/some/path?something=else#access_token=header.payload.signature"
+    )
+
+    private val invalid = listOf(
+            "my.app://my-dapp.com#access_token=header.payload.signature#degenerate-fragment",
+            "my.app://my-dapp.com?access_token=header.payload.signature",
+            "my.app://my-dapp.com#access_token=header.payload",
+            "my.app://my-dapp.com#access_token=",
+            "access_token=header.payload.signature",
+            ""
+    )
+
+    @Test
+    fun `parse jwt from URL`() {
+        valid.forEach { redirect ->
+            val token = ResponseParser.extractTokenFromRedirectUri(redirect)
+            println(token)
+            assertNotNull(token)
+        }
+    }
+
+    @Test
+    fun `reject invalid URIs`() {
+        invalid.forEach { redirect ->
+            val token = ResponseParser.extractTokenFromRedirectUri(redirect)
+            assertNull("expected parsing to fail at url: $redirect", token)
+        }
+    }
+
+}

--- a/universal-did/src/main/java/me/uport/sdk/universaldid/UniversalDID.kt
+++ b/universal-did/src/main/java/me/uport/sdk/universaldid/UniversalDID.kt
@@ -50,7 +50,7 @@ object UniversalDID : DIDResolver {
      * Looks for a [DIDResolver] that can resolve the provided [did] either by method if the did contains one or by trial
      *
      * @throws IllegalStateException if the proper resolver is not registered or produces `null`
-     * @throws [IllegalArgumentException] if the given [did] has no `method` but could be resolved by one of the registered resolvers and that one fails with `null`
+     * @throws IllegalArgumentException if the given [did] has no `method` but could be resolved by one of the registered resolvers and that one fails with `null`
      */
     override suspend fun resolve(did: String): DIDDocument {
         val (method, _) = parse(did)


### PR DESCRIPTION
### What's here

The bulk of this PR is the `ResponseParser` class that is able to extract `shareResp` JWTs from deep link replies.
Selective disclosure replies come in as deepLink URIs into a "router activity" that the developer is supposed to implement (The sample app it is called `DeeplinkActivity.kt`).
The 2 methods exposed enable devs to extract JWTs either directly from the `Intent` object received by the router activity or from an already processed URI (for more complex routing logic)

The demoapp has been updated to demonstrate a selective disclosure flow where the `name` field is requested from the uPort app and the response parsed and displayed.

### Testing

JVM Tests have been added and can be run using `./gradlew :transport:test`
The full suite can be run with `./gradlew clean test cC --no-parallel` with a device/emultator connected

This closes [#160661311](https://www.pivotaltracker.com/story/show/160661311) on pivotal