### PR TITLE
[Bug] Verify JWT timestamp

### DIFF
--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -30,10 +30,10 @@ class JWTToolsTests {
 
     @Test
     fun testVerifyToken() = runBlocking {
-        val shareReqPayload = JWTTools().verify(validShareReqToken1)
+        val shareReqPayload = JWTTools(TestTimeProvider(1520366666)).verify(validShareReqToken1)
         assertEquals(expectedShareReqPayload1, shareReqPayload)
 
-        val incomingJwtPayload = JWTTools().verify(incomingJwt)
+        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300)).verify(incomingJwt)
         assertEquals(expectedJwtPayload, incomingJwtPayload)
     }
 
@@ -56,7 +56,7 @@ class JWTToolsTests {
         val payload = JwtPayload(iss = "2oufEA35y7GiApcdyL87Lp5zTV7NRNCF6HH",
                 iat = 1522100396,
                 aud = "2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG",
-                exp = 1522186796,
+                exp = 1545314699,
                 type = "shareResp",
                 nad = "2oufEA35y7GiApcdyL87Lp5zTV7NRNCF6HH",
                 own = ownObj,
@@ -70,7 +70,9 @@ class JWTToolsTests {
 
             runBlocking {
                 // but we should be able to verify the newly created token
-                val newJwtPayload = JWTTools().verify(newJwt!!)
+
+                val timeProvider = TestTimeProvider(1532095437)
+                val newJwtPayload = JWTTools(timeProvider).verify(newJwt!!)
                 assertNotNull(newJwtPayload)
                 latch.countDown()
             }
@@ -109,6 +111,28 @@ class JWTToolsTests {
         UportHDSigner().importHDSeed(mActivityRule.activity, KeyProtection.Level.SIMPLE, phrase)
     }
 
+    @Test(expected = InvalidJWTException::class)
+    fun throws_when_iat_is_in_future() {
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
+
+        val timeProvider = TestTimeProvider(977317692000L)
+
+        runBlocking {
+            JWTTools(timeProvider).verify(token)
+        }
+    }
+
+    @Test(expected = InvalidJWTException::class)
+    fun throws_when_exp_is_in_the_past() {
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
+
+        val timeProvider = TestTimeProvider(1576847292000L)
+
+        runBlocking {
+            JWTTools(timeProvider).verify(token)
+        }
+    }
+
 
 }
 
@@ -116,4 +140,5 @@ class TestTimeProvider(private val currentTime: Long) : ITimeProvider {
     override fun now(): Long = currentTime
 
 }
+
 

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -30,10 +30,10 @@ class JWTToolsTests {
 
     @Test
     fun testVerifyToken() = runBlocking {
-        val shareReqPayload = JWTTools(TestTimeProvider(1520366666)).verify(validShareReqToken1)
+        val shareReqPayload = JWTTools(TestTimeProvider(1520366666L)).verify(validShareReqToken1)
         assertEquals(expectedShareReqPayload1, shareReqPayload)
 
-        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300)).verify(incomingJwt)
+        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300L)).verify(incomingJwt)
         assertEquals(expectedJwtPayload, incomingJwtPayload)
     }
 
@@ -71,7 +71,7 @@ class JWTToolsTests {
             runBlocking {
                 // but we should be able to verify the newly created token
 
-                val timeProvider = TestTimeProvider(1532095437)
+                val timeProvider = TestTimeProvider(1532095437L)
                 val newJwtPayload = JWTTools(timeProvider).verify(newJwt!!)
                 assertNotNull(newJwtPayload)
                 latch.countDown()

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -166,8 +166,8 @@ class JWTTools(
     /**
      * Verifies a jwt [token]
      * @params jwt token
+     * @throws InvalidJWTException when the current time is not within the time range of payload iat and exp
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
-     * //TODO: this should return or throw to differentiate network errors from invalid signatures
      */
     suspend fun verify(token: String): JwtPayload? {
         val (_, payload, signatureBytes) = decode(token)
@@ -175,11 +175,11 @@ class JWTTools(
         val now = timeProvider.now() + IAT_SKEW
 
         if (payload.iat != null && payload.iat > now) {
-            throw Error ("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
+            throw InvalidJWTException ("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
         }
 
         if (payload.exp != null && payload.exp < now) {
-            throw Error("JWT has expired: exp: ${payload.exp}")
+            throw InvalidJWTException("JWT has expired: exp: ${payload.exp}")
         }
 
         val ddo: DIDDocument = UniversalDID.resolve(payload.iss)

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -43,7 +43,7 @@ class JWTTools(
         private val timeProvider: ITimeProvider = SystemTimeProvider
 ) {
     private val notEmpty: (String) -> Boolean = { !it.isEmpty() }
-    private val IAT_SKEW = 300
+    private val TIME_SKEW = 300
 
     init {
 
@@ -172,13 +172,11 @@ class JWTTools(
     suspend fun verify(token: String): JwtPayload? {
         val (_, payload, signatureBytes) = decode(token)
 
-        val now = timeProvider.now() + IAT_SKEW
-
-        if (payload.iat != null && payload.iat > now) {
+        if (payload.iat != null && payload.iat > (timeProvider.now() - TIME_SKEW)) {
             throw InvalidJWTException ("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
         }
 
-        if (payload.exp != null && payload.exp < now) {
+        if (payload.exp != null && payload.exp < (timeProvider.now() + TIME_SKEW)) {
             throw InvalidJWTException("JWT has expired: exp: ${payload.exp}")
         }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -172,11 +172,11 @@ class JWTTools(
     suspend fun verify(token: String): JwtPayload? {
         val (_, payload, signatureBytes) = decode(token)
 
-        if (payload.iat != null && payload.iat > (timeProvider.now() - TIME_SKEW)) {
+        if (payload.iat != null && payload.iat > (timeProvider.now() + TIME_SKEW)) {
             throw InvalidJWTException ("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
         }
 
-        if (payload.exp != null && payload.exp < (timeProvider.now() + TIME_SKEW)) {
+        if (payload.exp != null && payload.exp <= (timeProvider.now() - TIME_SKEW)) {
             throw InvalidJWTException("JWT has expired: exp: ${payload.exp}")
         }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -2,6 +2,7 @@ package me.uport.sdk.jwt
 
 import com.uport.sdk.signer.KPSigner
 import kotlinx.coroutines.runBlocking
+import me.uport.sdk.core.ITimeProvider
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -16,7 +17,7 @@ class JWTToolsJVMTest {
     fun verify() = runBlocking {
 
         tokens.forEach { token ->
-            val payload = JWTTools().verify(token)
+            val payload = JWTTools(JVMTestTimeProvider(1535102500L)).verify(token)
             assertNotNull(payload)
         }
     }
@@ -34,5 +35,10 @@ class JWTToolsJVMTest {
         val unused = tested.createJWT(payload, issuerDID, signer, algorithm = "some fancy but unknown algorithm")
 
     }
+}
+
+class JVMTestTimeProvider(private val currentTime: Long) : ITimeProvider {
+    override fun now(): Long = currentTime
+
 }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/model/TestTimeProvider.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/model/TestTimeProvider.kt
@@ -1,8 +1,0 @@
-package me.uport.sdk.jwt.model
-
-import me.uport.sdk.core.ITimeProvider
-
-class TestTimeProvider(private val currentTime: Long) : ITimeProvider {
-    override fun now(): Long = currentTime
-
-}

--- a/jwt/src/test/java/me/uport/sdk/jwt/model/TestTimeProvider.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/model/TestTimeProvider.kt
@@ -1,0 +1,8 @@
+package me.uport.sdk.jwt.model
+
+import me.uport.sdk.core.ITimeProvider
+
+class TestTimeProvider(private val currentTime: Long) : ITimeProvider {
+    override fun now(): Long = currentTime
+
+}


### PR DESCRIPTION
#### What's Here

Pivotal Tracker: https://www.pivotaltracker.com/story/show/162662579

Throws `InvalidJWTException` when the current time via the TimeProvider is not within the range of `iat` and `exp`

#### Testing
JVM Tests have been added and can be run using ./gradlew :jwt:test
The full suite can be run with ./gradlew clean test cC --no-parallel with a device/emultator connected