### PR TITLE
JWT Verification Exception Handling

### DIFF
--- a/demoapp/src/main/java/me/uport/sdk/demoapp/VerifyJWTActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/VerifyJWTActivity.kt
@@ -7,6 +7,7 @@ import kotlinx.android.synthetic.main.verify_jwt.*
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import me.uport.sdk.core.ITimeProvider
 import me.uport.sdk.core.UI
 import me.uport.sdk.jwt.JWTTools
 
@@ -27,7 +28,7 @@ class VerifyJWTActivity : AppCompatActivity() {
 
             GlobalScope.launch {
 
-                val payload = JWTTools().verify(jwtToken)
+                val payload = JWTTools(TimeProvider(1520366435000L)).verify(jwtToken)
 
                 withContext(UI) {
                     jwtPayload.text = payload?.toString()
@@ -36,4 +37,8 @@ class VerifyJWTActivity : AppCompatActivity() {
             }
         }
     }
+}
+class TimeProvider(private val currentTime: Long) : ITimeProvider {
+    override fun now(): Long = currentTime
+
 }

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -30,10 +30,10 @@ class JWTToolsTests {
 
     @Test
     fun testVerifyToken() = runBlocking {
-        val shareReqPayload = JWTTools(TestTimeProvider(1520366666L)).verify(validShareReqToken1)
+        val shareReqPayload = JWTTools(TestTimeProvider(1520366666000L)).verify(validShareReqToken1)
         assertEquals(expectedShareReqPayload1, shareReqPayload)
 
-        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300L)).verify(incomingJwt)
+        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300000L)).verify(incomingJwt)
         assertEquals(expectedJwtPayload, incomingJwtPayload)
     }
 
@@ -71,7 +71,7 @@ class JWTToolsTests {
             runBlocking {
                 // but we should be able to verify the newly created token
 
-                val timeProvider = TestTimeProvider(1532095437L)
+                val timeProvider = TestTimeProvider(1532095437000L)
                 val newJwtPayload = JWTTools(timeProvider).verify(newJwt!!)
                 assertNotNull(newJwtPayload)
                 latch.countDown()
@@ -139,7 +139,7 @@ class JWTToolsTests {
         // JWT token with a Signer that doesn't have anything to do with the issuerDID.
         val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NDY4NTkxNTksImV4cCI6MTg2MjIxOTE1OSwiaXNzIjoiZGlkOmV0aHI6MHg2OTg1YTExMGRmMzc1NTUyMzVkN2QwZGUwYTBmYjI4Yzk4NDhkZmE5In0.fe1rvAHsoJsJzwSFAmVFTz9uxhncNY65jpbb2cS9jcY08xphpU3rOy1N85_IbEjhIZw-FrPeFgxJLoDLw6itcgE"
 
-        val timeProvider = TestTimeProvider(1547818630L)
+        val timeProvider = TestTimeProvider(1547818630000L)
 
         runBlocking {
             JWTTools(timeProvider).verify(token)

--- a/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
+++ b/jwt/src/androidTest/java/me/uport/sdk/jwt/JWTToolsTests.kt
@@ -133,6 +133,19 @@ class JWTToolsTests {
         }
     }
 
+    @Test(expected = InvalidJWTException::class)
+    fun throws_exception_when_no_matching_public_key() {
+
+        // JWT token with a Signer that doesn't have anything to do with the issuerDID.
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NDY4NTkxNTksImV4cCI6MTg2MjIxOTE1OSwiaXNzIjoiZGlkOmV0aHI6MHg2OTg1YTExMGRmMzc1NTUyMzVkN2QwZGUwYTBmYjI4Yzk4NDhkZmE5In0.fe1rvAHsoJsJzwSFAmVFTz9uxhncNY65jpbb2cS9jcY08xphpU3rOy1N85_IbEjhIZw-FrPeFgxJLoDLw6itcgE"
+
+        val timeProvider = TestTimeProvider(1547818630L)
+
+        runBlocking {
+            JWTTools(timeProvider).verify(token)
+        }
+    }
+
 
 }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -167,7 +167,6 @@ class JWTTools(
      * Verifies a jwt [token]
      * @params jwt token
      * @throws InvalidJWTException when the current time is not within the time range of payload iat and exp
-     *          when no signatures can be generated from the recoveryByte
      *          when no public key matches are found in the DID document
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
      */
@@ -175,7 +174,7 @@ class JWTTools(
         val (_, payload, signatureBytes) = decode(token)
 
         if (payload.iat != null && payload.iat > (timeProvider.now() + TIME_SKEW)) {
-            throw InvalidJWTException ("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
+            throw InvalidJWTException("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
         }
 
         if (payload.exp != null && payload.exp <= (timeProvider.now() - TIME_SKEW)) {
@@ -196,10 +195,6 @@ class JWTTools(
         // Generate signature from recovery byte
         val signatures = recoveryBytes.map {
             signatureBytes.decodeJose(it)
-        }
-
-        if (signatures.isEmpty()) {
-            throw InvalidJWTException ("No signatures found")
         }
 
         for (sigData in signatures) {

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -173,11 +173,11 @@ class JWTTools(
     suspend fun verify(token: String): JwtPayload? {
         val (_, payload, signatureBytes) = decode(token)
 
-        if (payload.iat != null && payload.iat > (timeProvider.now() + TIME_SKEW)) {
+        if (payload.iat != null && payload.iat > (timeProvider.now()/1000 + TIME_SKEW)) {
             throw InvalidJWTException("Jwt not valid yet (issued in the future) iat: ${payload.iat}")
         }
 
-        if (payload.exp != null && payload.exp <= (timeProvider.now() - TIME_SKEW)) {
+        if (payload.exp != null && payload.exp <= (timeProvider.now()/1000 - TIME_SKEW)) {
             throw InvalidJWTException("JWT has expired: exp: ${payload.exp}")
         }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -17,7 +17,7 @@ class JWTToolsJVMTest {
     fun verify() = runBlocking {
 
         tokens.forEach { token ->
-            val payload = JWTTools(JVMTestTimeProvider(1535102500L)).verify(token)
+            val payload = JWTTools(JVMTestTimeProvider(1535102500000L)).verify(token)
             assertNotNull(payload)
         }
     }


### PR DESCRIPTION
#### What's here
Solution to the User Story https://www.pivotaltracker.com/story/show/162701140

Improve exception handling in `JWTTools.verify()` by throwing specific errors and not returning null 

#### Testing
One test added to `JWTToolsTest`
Run using the command ./gradlew clean jwt:test cC --no-parallel when connected to an emulator