### PR TITLE
Feature/Connecting a DID to an Account

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     api "com.github.walleth.kethereum:model:$kethereum_version"
     api project(':uport-did')
+    api project(':ethr-did')
     api project(":core")
     api project(":signer")
     api project(":serialization")

--- a/identity/src/main/java/me/uport/sdk/identity/Account.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/Account.kt
@@ -56,6 +56,23 @@ data class Account(
 
     fun getSigner(context: Context): Signer = UportHDSignerImpl(context, UportHDSigner(), rootAddress = handle, deviceAddress = deviceAddress)
 
+    /**
+     * This function generates the DID associated with an account based on the account type.
+     *
+     * Limitation: The current implementation only covers KeyPair and MetaIdentity Account types
+     * @return the DID as a string
+     * @throws IllegalStateException if there is no implementation for the Account Type
+     */
+    fun getDID(): String {
+        if (type.equals(AccountType.MetaIdentityManager)) {
+            return "did:uport:${getMnid()}"
+        } else if (type.equals(AccountType.KeyPair)) {
+            return "did:ethr:$publicAddress"
+        } else {
+            throw IllegalStateException("A DID could not be created for the Account Type $type")
+        }
+    }
+
     companion object {
 
         val blank = Account("", "", "", "", "", "", "", AccountType.KeyPair)

--- a/identity/src/main/java/me/uport/sdk/identity/Account.kt
+++ b/identity/src/main/java/me/uport/sdk/identity/Account.kt
@@ -60,16 +60,14 @@ data class Account(
      * This function generates the DID associated with an account based on the account type.
      *
      * Limitation: The current implementation only covers KeyPair and MetaIdentity Account types
-     * @return the DID as a string
+     * @returns the DID as a string
      * @throws IllegalStateException if there is no implementation for the Account Type
      */
     fun getDID(): String {
-        if (type.equals(AccountType.MetaIdentityManager)) {
-            return "did:uport:${getMnid()}"
-        } else if (type.equals(AccountType.KeyPair)) {
-            return "did:ethr:$publicAddress"
-        } else {
-            throw IllegalStateException("A DID could not be created for the Account Type $type")
+        return when (type) {
+            AccountType.MetaIdentityManager -> "did:uport:${getMnid()}"
+            AccountType.KeyPair -> "did:ethr:$publicAddress"
+            else -> throw IllegalStateException("A DID could not be created for the Account Type $type")
         }
     }
 

--- a/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
+++ b/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
@@ -1,5 +1,9 @@
 package me.uport.sdk.identity
 
+import me.uport.sdk.core.Networks
+import me.uport.sdk.ethrdid.EthrDIDResolver
+import me.uport.sdk.jsonrpc.JsonRPC
+import me.uport.sdk.uportdid.UportDIDResolver
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -52,5 +56,67 @@ class AccountsTests {
 
         assertFalse(account.isDefault!!)
     }
+
+    @Test
+    fun validate_did_from_keypair_account() {
+
+        val serializedAccount = """
+            {
+                "uportRoot": "0x1f9339e3c08c120b4ee05d2f500d57000170664d",
+                "devKey": "0x95979bb3ee68420a0b105f6e3c0d5d0fc0466016",
+                "network": "0x04",
+                "proxy": "0x95979bb3ee68420a0b105f6e3c0d5d0fc0466016",
+                "manager": "",
+                "txRelay": "",
+                "fuelToken": "",
+                "signerType": "KeyPair",
+                "isDefault": true
+            }""".trimIndent()
+
+        val account = Account.fromJson(serializedAccount)
+        val defaultRPC = JsonRPC(Networks.mainnet.rpcUrl)
+        val canResolve = EthrDIDResolver(defaultRPC).canResolve(account!!.getDID())
+        assertTrue(canResolve)
+    }
+
+    @Test
+    fun validate_did_from_meta_identity_account() {
+
+        val serializedAccount = """
+            {
+              "uportRoot":"0xrootAddress",
+              "devKey":"0xaddress",
+              "network":"0x4",
+              "proxy":"0xpublicaddress",
+              "manager":"0xidentityManagerAddress",
+              "txRelay":"0xtxRelayAddress",
+              "fuelToken":"base64FuelToken",
+              "signerType":"MetaIdentityManager"
+            }""".trimIndent()
+
+        val account = Account.fromJson(serializedAccount)
+        val canResolve = UportDIDResolver().canResolve(account!!.getDID())
+        assertTrue(canResolve)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun throws_error_for_invalid_account_type() {
+
+        val serializedAccount = """
+            {
+              "uportRoot":"0xrootAddress",
+              "devKey":"0xaddress",
+              "network":"0x4",
+              "proxy":"0xpublicaddress",
+              "manager":"0xidentityManagerAddress",
+              "txRelay":"0xtxRelayAddress",
+              "fuelToken":"base64FuelToken",
+              "signerType":"Proxy"
+            }""".trimIndent()
+
+        val account = Account.fromJson(serializedAccount)
+        account!!.getDID()
+    }
+
 
 }


### PR DESCRIPTION
 #### What's here

This provides a function which allows developers access the DID associated with accounts created via uPort. More details can be found in the US https://www.pivotaltracker.com/story/show/162697134


#### Testing
3 JVM tests added to `AccountTests`
Run with `./gradlew :identity:test`