### PR TITLE
add maven publishing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# repo-specific config
+publish.properties
+
 
 # Created by https://www.gitignore.io/api/linux,macos,gradle,windows,android,androidstudio
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,14 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath "com.github.gnosis.bivrost-kotlin:bivrost-gradle-plugin:$bivrost_version"
+
+        classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
     }
+}
+
+plugins {
+    id "io.errorlab.gradle.vault" version "0.1.0"
 }
 
 allprojects {
@@ -83,32 +90,7 @@ allprojects {
     }
 }
 
-subprojects { subproject ->
-    afterEvaluate {
-        if (subproject.plugins.hasPlugin('maven')) {
-
-            group "me.uport.sdk"
-            version uport_sdk_version
-
-            uploadArchives {
-                repositories {
-                    mavenDeployer {
-                        if (project.hasProperty("MAVEN_REPOSITORY")) {
-                            //nop
-                        } else {
-                            repository(url: mavenLocal().url)
-                        }
-                    }
-                }
-            }
-
-        }
-
-        if (subproject.plugins.hasPlugin("com.android.application") || subproject.plugins.hasPlugin("com.android.library")) {
-            subproject.android.packagingOptions.exclude("META-INF/main.kotlin_module")
-        }
-    }
-}
+apply from: "publishing.gradle"
 
 task clean(type: Delete) {
     delete rootProject.buildDir

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,16 @@ allprojects {
     }
 }
 
+subprojects { subproject ->
+
+    afterEvaluate {
+
+        if (subproject.plugins.hasPlugin("com.android.application") || subproject.plugins.hasPlugin("com.android.library")) {
+            subproject.android.packagingOptions.exclude("META-INF/main.kotlin_module")
+        }
+    }
+}
+
 apply from: "publishing.gradle"
 
 task clean(type: Delete) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,8 @@ apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "core classes of the uPort android SDK"
+
 android {
     compileSdkVersion compile_sdk_version
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/credentials/build.gradle
+++ b/credentials/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
-apply plugin: "maven"
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/credentials/build.gradle
+++ b/credentials/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "kotlinx-serialization"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "tools for creating, requesting, and verifying signed claims"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -2,9 +2,8 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
 apply plugin: "bivrost"
-apply plugin: "maven"
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -5,6 +5,8 @@ apply plugin: "bivrost"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "DID resolver for the ethr-did (ERC 1056) lightweight identity standard"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/fuelingservice/build.gradle
+++ b/fuelingservice/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: "maven"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/https-did/build.gradle
+++ b/https-did/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/https-did/build.gradle
+++ b/https-did/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "resolver for the https-did method"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "kotlinx-serialization"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "classes for creating and managing uPort Account objects"
+
 android {
     compileSdkVersion compile_sdk_version
 

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -3,6 +3,8 @@ apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "wrappers for calling ethereum endpoints using json-rpc"
+
 android {
     compileSdkVersion compile_sdk_version
 

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -3,6 +3,8 @@ apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "tools for creating and verifying JWTs that use uPort algorithms"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'maven'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version
@@ -21,7 +22,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
 
@@ -37,7 +38,7 @@ dependencies {
     api "com.github.walleth.kethereum:extensions:$kethereum_version"
 
     api project(":signer")
-    api project(':uport-did')
+    api project(":uport-did")
     api project(":ethr-did")
     api project(":https-did")
     api project(":jsonrpc")

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,104 @@
+subprojects { subproject ->
+
+    subproject.group = 'com.github.uport-project.uport-android-sdk'
+    subproject.version = uport_sdk_version
+
+    afterEvaluate {
+
+        if (subproject.plugins.hasPlugin('com.github.dcendents.android-maven')) {
+
+            task sourcesJar(type: Jar) {
+                classifier = 'sources'
+                from android.sourceSets.main.javaDirectories
+            }
+
+            artifacts {
+                archives sourcesJar
+            }
+
+            bintray {
+                user = "uport-project"
+                key = getBintrayApiKey()
+
+                configurations = ['archives']
+
+                pkg {
+                    repo = "uport-project"
+                    name = subproject.name
+                    licenses = ['Apache-2.0']
+                    vcsUrl = 'https://github.com/uport-project/uport-android-sdk.git'
+                    dryRun = true
+                    publish = true
+                    override = true
+                    publicDownloadNumbers = false
+                    version {
+                        name = uport_sdk_version
+                        released = new Date()
+                    }
+                }
+            }
+
+        }
+
+        if (subproject.plugins.hasPlugin("com.android.application") || subproject.plugins.hasPlugin("com.android.library")) {
+            subproject.android.packagingOptions.exclude("META-INF/main.kotlin_module")
+        }
+    }
+}
+
+def getBintrayApiKey() {
+    checkVaultEnvironment()
+    String apiKey
+    if (project.publishProps?.get("bintray_api_key") != null) {
+        apiKey = project.publishProps?.get("bintray_api_key")
+    } else if (project.hasProperty("IGNORE_VAULT")) {
+        apiKey = ""
+    } else {
+        try {
+            apiKey = project?.vault?.get("secret/android_sdk/bintray_api_key")['data']['value']
+        } catch (Exception e) {
+            throw new InvalidUserDataException("There was an error while reading the bintray api key from vault.\n" +
+                    "Make sure to have secret/android_sdk/bintray_api_key in the vault.\n" +
+                    "Run this task with -PIGNORE_VAULT to default to local configuration if available", e)
+        }
+    }
+    return apiKey
+}
+
+def checkVaultEnvironment() {
+
+    checkLocalPublishingProperties()
+
+    if (project.hasProperty("IGNORE_VAULT")) {
+        //use only local data if available
+        return
+    }
+
+    File tokenFile = new File("${System.env.HOME}/.vault-token")
+
+    if (tokenFile.canRead()) {
+        if (System.env.VAULT_TOKEN == null || System.env.VAULT_TOKEN == "") {
+            project?.vault?.token = tokenFile.text
+        }
+    }
+
+    if (System.env.VAULT_ADDR == null || (System.env.VAULT_TOKEN == null && !tokenFile.canRead())) {
+        throw new InvalidUserDataException("Vault coordinates are not configured.\n" +
+                "VAULT_ADDR and VAULT_TOKEN need to be set as environment variables.\n" +
+                "Run this task with -PIGNORE_VAULT to skip secrets and build using local configuration only")
+    }
+}
+
+def checkLocalPublishingProperties() {
+    def propFile = file("${rootDir}/publish.properties")
+    if (propFile.canRead()) {
+
+        Properties publishProps = new Properties()
+        propFile.withInputStream {
+            publishProps.load(it)
+        }
+        project.ext.publishProps = publishProps
+    } else {
+        project.ext.publishProps = null
+    }
+}

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -63,26 +63,28 @@ subprojects { subproject ->
             }
 
             //config for jcenter
-            bintray {
-                user = getBintrayUser()
-                key = getBintrayApiKey()
+            if (gradle.startParameter.taskNames.find { it.contains("bintray") }) {
+                bintray {
+                    user = getBintrayUser()
+                    key = getBintrayApiKey()
 
-                configurations = ['archives']
+                    configurations = ['archives']
 
-                pkg {
-                    repo = "uport-project"
-                    name = subproject.name
-                    licenses = ["Apache-2.0"]
-                    desc = subproject.description
-                    websiteUrl = siteUrl
-                    vcsUrl = gitUrl
-                    dryRun = false
-                    publish = true
-                    override = true
-                    publicDownloadNumbers = false
-                    version {
-                        name = uport_sdk_version
-                        released = new Date()
+                    pkg {
+                        repo = "uport-project"
+                        name = subproject.name
+                        licenses = ["Apache-2.0"]
+                        desc = subproject.description
+                        websiteUrl = siteUrl
+                        vcsUrl = gitUrl
+                        dryRun = false
+                        publish = true
+                        override = true
+                        publicDownloadNumbers = false
+                        version {
+                            name = uport_sdk_version
+                            released = new Date()
+                        }
                     }
                 }
             }

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,4 +1,4 @@
-// this relies on a vault connection or the presence of a publishing.properties file with:
+// this relies on a vault connection or the presence of a publish.properties file with:
 // bintray_api_key
 // bintray_username
 

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,11 +1,57 @@
-subprojects { subproject ->
+// this relies on a vault connection or the presence of a publishing.properties file with:
+// bintray_api_key
+// bintray_username
 
-    subproject.group = 'com.github.uport-project.uport-android-sdk'
-    subproject.version = uport_sdk_version
+
+def gitUrl = "https://github.com/uport-project/uport-android-sdk.git"
+def groupID = "com.github.uport-project.uport-android-sdk"
+def siteUrl = "https://developer.uport.me"
+def sdkDescription = "uPort SDK for android"
+
+subprojects { subproject ->
 
     afterEvaluate {
 
         if (subproject.plugins.hasPlugin('com.github.dcendents.android-maven')) {
+
+            subproject.group = groupID
+            subproject.version = uport_sdk_version
+            subproject.description = subproject.ext.has("description") ? subproject.ext.description : sdkDescription
+
+            //pom fields required by maven central
+            install {
+                repositories.mavenInstaller {
+                    pom.project {
+                        packaging 'aar'
+                        groupId subproject.group
+                        artifactId subproject.name
+
+                        name subproject.name
+                        description subproject.description
+
+                        url siteUrl
+
+                        licenses {
+                            license {
+                                name "The Apache Software License, Version 2.0"
+                                url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                            }
+                        }
+                        developers {
+                            developer {
+                                id "mirceanis"
+                                name "Mircea Nistor"
+                                email "mircea.nistor@consensys.net"
+                            }
+                        }
+                        scm {
+                            connection gitUrl
+                            developerConnection gitUrl
+                            url siteUrl
+                        }
+                    }
+                }
+            }
 
             task sourcesJar(type: Jar) {
                 classifier = 'sources'
@@ -16,8 +62,9 @@ subprojects { subproject ->
                 archives sourcesJar
             }
 
+            //config for jcenter
             bintray {
-                user = "uport-project"
+                user = getBintrayUser()
                 key = getBintrayApiKey()
 
                 configurations = ['archives']
@@ -25,9 +72,11 @@ subprojects { subproject ->
                 pkg {
                     repo = "uport-project"
                     name = subproject.name
-                    licenses = ['Apache-2.0']
-                    vcsUrl = 'https://github.com/uport-project/uport-android-sdk.git'
-                    dryRun = true
+                    licenses = ["Apache-2.0"]
+                    desc = subproject.description
+                    websiteUrl = siteUrl
+                    vcsUrl = gitUrl
+                    dryRun = false
                     publish = true
                     override = true
                     publicDownloadNumbers = false
@@ -46,28 +95,41 @@ subprojects { subproject ->
     }
 }
 
+//////////////////////////////////////////////////
+// helpers for loading publishing configuration //
+//////////////////////////////////////////////////
+
 def getBintrayApiKey() {
+    return getInfoFromPropOrVault("bintray_api_key")
+}
+
+def getBintrayUser() {
+    return getInfoFromPropOrVault("bintray_username")
+}
+
+def getInfoFromPropOrVault(String key) {
+
+    checkLocalPublishingProperties()
     checkVaultEnvironment()
-    String apiKey
-    if (project.publishProps?.get("bintray_api_key") != null) {
-        apiKey = project.publishProps?.get("bintray_api_key")
+
+    String info
+    if (project.publishProps?.get(key) != null) {
+        info = project.publishProps?.get(key)
     } else if (project.hasProperty("IGNORE_VAULT")) {
-        apiKey = ""
+        info = ""
     } else {
         try {
-            apiKey = project?.vault?.get("secret/android_sdk/bintray_api_key")['data']['value']
+            info = project?.vault?.get("secret/android_sdk/$key")['data']['value']
         } catch (Exception e) {
-            throw new InvalidUserDataException("There was an error while reading the bintray api key from vault.\n" +
-                    "Make sure to have secret/android_sdk/bintray_api_key in the vault.\n" +
+            throw new InvalidUserDataException("There was an error while reading $key from vault.\n" +
+                    "Make sure to have secret/android_sdk/$key in the vault.\n" +
                     "Run this task with -PIGNORE_VAULT to default to local configuration if available", e)
         }
     }
-    return apiKey
+    return info
 }
 
 def checkVaultEnvironment() {
-
-    checkLocalPublishingProperties()
 
     if (project.hasProperty("IGNORE_VAULT")) {
         //use only local data if available

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -89,9 +89,6 @@ subprojects { subproject ->
 
         }
 
-        if (subproject.plugins.hasPlugin("com.android.application") || subproject.plugins.hasPlugin("com.android.library")) {
-            subproject.android.packagingOptions.exclude("META-INF/main.kotlin_module")
-        }
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "bivrost"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "wrapper library for the uPort SDK"
+
 android {
     compileSdkVersion compile_sdk_version
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "bivrost"
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "kotlinx-serialization"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "tools for (de)serializing objects used by the uPort SDK"
+
 android {
     compileSdkVersion compile_sdk_version
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
-apply plugin: "maven"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-apply plugin: "maven"
-
-//apply from: "https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle"
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version
@@ -53,24 +52,3 @@ dependencies {
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
-
-//
-//task androidJavadocs(type: Javadoc) {
-//    source = android.sourceSets.main.java.srcDirs
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-//}
-//
-//task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-//    classifier = "javadoc"
-//    from androidJavadocs.destinationDir
-//}
-
-task androidSourcesJar(type: Jar) {
-    classifier = "sources"
-    from android.sourceSets.main.java.sourceFiles
-}
-
-artifacts {
-    archives androidSourcesJar
-//    archives androidJavadocsJar
-}

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -3,6 +3,8 @@ apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "Signer abstractions including key management APIs that rely on AndroidKeyStore to protect keys at rest"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "kotlinx-serialization"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "tools for communication with other uPort layers or between different client implementations"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
-apply plugin: "maven"
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/universal-did/build.gradle
+++ b/universal-did/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlinx-serialization"
-apply plugin: "maven"
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/universal-did/build.gradle
+++ b/universal-did/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "kotlinx-serialization"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "wrapper for multiple DID resolvers"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "bivrost"
-apply plugin: "maven"
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "com.jfrog.bintray"
 
 android {
     compileSdkVersion compile_sdk_version

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "bivrost"
 apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
+project.ext.description = "DID resolver for the uport-did standard"
+
 android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version


### PR DESCRIPTION
This PR adds the configuration needed for publishing the sdk libraries to a maven repo.

This fixes [#162411452](https://www.pivotaltracker.com/story/show/162411452) from pivotal as well.
Developers can click through SDK sources right from android studio.