### PR TITLE
[Feature] define jwt types for verification and personal sign requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         kotlin_serialization_version = '0.9.1'
         coroutines_version = "1.0.1"
 
-        android_tools_version = '3.3.0'
+        android_tools_version = '3.3.1'
 
         build_tools_version = "28.0.3"
 

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -8,8 +8,8 @@ object Networks {
 
     val mainnet = EthNetwork(
             "mainnet",
-            "0x01",
-            MNID.encode("0x01", "0xab5c8051b9a1df1aab0149f8b0630848b7ecabf6"),
+            "0x1",
+            MNID.encode("0x1", "0xab5c8051b9a1df1aab0149f8b0630848b7ecabf6"),
             "https://mainnet.infura.io/uport",
             "https://etherscan.io",
             "https://sensui.uport.me/api/v1/fund/",
@@ -17,8 +17,8 @@ object Networks {
             "0xec2642cd5a47fd5cca2a8a280c3b5f88828aa578")
     val ropsten = EthNetwork(
             "ropsten",
-            "0x03",
-            MNID.encode("0x03", "0x41566e3a081f5032bdcad470adb797635ddfe1f0"),
+            "0x3",
+            MNID.encode("0x3", "0x41566e3a081f5032bdcad470adb797635ddfe1f0"),
             "https://ropsten.infura.io/uport",
             "https://ropsten.io",
             "https://sensui.uport.me/api/v1/fund/",
@@ -35,8 +35,8 @@ object Networks {
             "0xa9235151d3afa7912e9091ab76a36cbabe219a0c")
     val rinkeby = EthNetwork(
             "rinkeby",
-            "0x04",
-            MNID.encode("0x04", "0x2cc31912b2b0f3075a87b3640923d45a26cef3ee"),
+            "0x4",
+            MNID.encode("0x4", "0x2cc31912b2b0f3075a87b3640923d45a26cef3ee"),
             "https://rinkeby.infura.io/uport",
             "https://rinkeby.etherscan.io",
             "https://api.uport.me/sensui/fund/",
@@ -47,10 +47,10 @@ object Networks {
      * a mapping between the ethereum network identifier and the related endpoints and metadata
      */
     private val NETWORK_CONFIG = mapOf(
-            "0x01" to mainnet,
-            "0x03" to ropsten,
+            "0x1" to mainnet,
+            "0x3" to ropsten,
             "0x2a" to kovan,
-            "0x04" to rinkeby
+            "0x4" to rinkeby
     ).toMutableMap()
 
     fun registerNetwork(networkId: String, network: EthNetwork) {
@@ -61,15 +61,16 @@ object Networks {
     }
 
     /**
-     * Gets an [EthNetwork] based on a networkId
+     * Gets an [EthNetwork] based on a [networkId]
      */
     fun get(networkId: String): EthNetwork {
-        val cleanNetId = networkId.clean0xPrefix().padStart(2, '0').prepend0xPrefix()
+        val cleanNetId = cleanId(networkId)
         return NETWORK_CONFIG[cleanNetId]
+                ?: NETWORK_CONFIG[networkId]
                 ?: throw IllegalStateException("network [$networkId] not configured")
     }
 
-    private fun cleanId(id: String) = id.clean0xPrefix().padStart(2, '0').prepend0xPrefix()
+    private fun cleanId(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()
 
 }
 

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -42,6 +42,57 @@ class Credentials(
     }
 
     /**
+     * Create a JWT requesting an eth_sign/personal_sign from a user of another uPort client app.
+     *
+     * See https://github.com/uport-project/specs/blob/develop/messages/personalsignreq.md
+     *
+     * Example:
+     * ```
+     *  val reqParams = PersonalSignRequestParams(
+     *                      data = "This is the message to be signed",
+     *                      callbackUrl = "https://myserver.com"
+     *                  )
+     *  val jwt = credentials.createPersonalSignRequest(reqParams)
+     *
+     *  // ... send jwt to the relevant party and expect a callback with the response at https://myserver.com
+     *
+     *  ```
+     */
+    suspend fun createPersonalSignRequest(params: PersonalSignRequestParams): String {
+        val payload = buildPayloadForPersonalSignReq(params)
+        return this.signJWT(payload, params.expiresInSeconds
+                ?: DEFAULT_PERSONAL_SIGN_REQ_VALIDITY_SECONDS)
+    }
+
+    /**
+     * Create a JWT requesting a verified claim from a user of another uPort client app.
+     *
+     * See https://github.com/uport-project/specs/blob/develop/messages/verificationreq.md
+     *
+     * Example:
+     * ```
+     *  val reqParams = VerifiedClaimRequestParams(
+     *                      unsignedClaim = mapOf(
+     *                          "Citizen of city X" to mapOf(
+     *                              "Allowed to vote" to true,
+     *                              "Document" to "QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW"
+     *                          )
+     *                      ),
+     *                      callbackUrl = "https://myserver.com"
+     *                  )
+     *  val jwt = credentials.createVerificationSignatureRequest(reqParams)
+     *
+     *  // ... send jwt to the relevant party and expect a callback with the response at https://myserver.com
+     *
+     *  ```
+     */
+    suspend fun createVerificationSignatureRequest(params: VerifiedClaimRequestParams): String {
+        val payload = buildPayloadForVerifiedClaimReq(params)
+        return this.signJWT(payload, params.expiresInSeconds
+                ?: DEFAULT_VERIFIED_CLAIM_REQ_VALIDITY_SECONDS)
+    }
+
+    /**
      *  Creates a JWT using the given [payload], issued and signed using the [did] and [signer]
      *  fields of this [Credentials] instance.
      *

--- a/credentials/src/main/java/me/uport/sdk/credentials/JWTType.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/JWTType.kt
@@ -25,7 +25,11 @@ enum class JWTType {
      */
     verReq,
 
-    //FIXME: there is no `verResp` type coming back from the uPort app. It has to be inferred from the presence of the `claim` field
+    /**
+     * FIXME: there is no `verResp` type coming back from the uPort app. It has to be inferred from the presence of the `claim` field
+     * This is a synthetic JWTType
+     */
+    verResp,
 
     /**
      * See also:  https://github.com/uport-project/specs/blob/develop/messages/signtypeddata.md

--- a/credentials/src/main/java/me/uport/sdk/credentials/JWTType.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/JWTType.kt
@@ -7,7 +7,7 @@ import android.support.annotation.Keep
  */
 @Keep
 @Suppress("EnumEntryName")
-enum class RequestType {
+enum class JWTType {
     /**
      * a selective disclosure request
      * See also:  https://github.com/uport-project/specs/blob/develop/messages/sharereq.md
@@ -25,13 +25,30 @@ enum class RequestType {
      */
     verReq,
 
+    //FIXME: there is no `verResp` type coming back from the uPort app. It has to be inferred from the presence of the `claim` field
+
     /**
      * See also:  https://github.com/uport-project/specs/blob/develop/messages/signtypeddata.md
      */
     eip712Req,
 
     /**
+     * See also: https://github.com/uport-project/specs/blob/develop/messages/signtypeddataresp.md
+     */
+    eip712Resp,
+
+    /**
      * See also:  https://github.com/uport-project/specs/blob/develop/messages/tx.md
      */
-    ethtx
+    ethtx,
+
+    /**
+     * https://github.com/uport-project/specs/blob/develop/messages/personalsignreq.md
+     */
+    personalSigReq,
+
+    /**
+     * https://github.com/uport-project/specs/blob/develop/messages/personalsignresp.md
+     */
+    personalSignResp
 }

--- a/credentials/src/main/java/me/uport/sdk/credentials/JWTTypes.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/JWTTypes.kt
@@ -7,7 +7,7 @@ import android.support.annotation.Keep
  */
 @Keep
 @Suppress("EnumEntryName")
-enum class JWTType {
+enum class JWTTypes {
     /**
      * a selective disclosure request
      * See also:  https://github.com/uport-project/specs/blob/develop/messages/sharereq.md

--- a/credentials/src/main/java/me/uport/sdk/credentials/PersonalSignRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/PersonalSignRequestParams.kt
@@ -1,0 +1,96 @@
+@file:Suppress("KDocUnresolvedReference")
+
+package me.uport.sdk.credentials
+
+/**
+ * A class that encapsulates the supported parameter types for creating a Personal Sign request.
+ *
+ * See
+ * https://github.com/uport-project/specs/blob/develop/messages/personalsignreq.md
+ *
+ * The parameters in this class get encoded in the JWT that represents such a request.
+ *
+ * While the JWT can be manually constructed, this class is provided for discoverability
+ * and ease of use of frequently used params.
+ */
+class PersonalSignRequestParams(
+
+        /**
+         * [**required**]
+         * A string containing the message to be signed.
+         */
+        val data: String,
+
+        /**
+         * [**optional**]
+         * Callback URL for returning the response to a request (may be deprecated in future)
+         *
+         * This gets encoded as `callback` in the resulting JWT
+         */
+        val callbackUrl: String? = null,
+
+        /**
+         * [**optional**]
+         * The DID of the identity you want to sign the Verified Claim.
+         *
+         * This can be pre-requested with a selective disclosure request
+         */
+        val riss: String? = null,
+
+        /**
+         * [**optional**]
+         * Hex encoded address requested to sign the transaction.
+         * If not specified the user will select an account.
+         */
+        val from: String? = null,
+
+        /**
+         * network id of Ethereum chain of identity
+         * eg. 0x4 for rinkeby. It defaults to 0x1 for mainnet.
+         */
+        val networkId: String? = null,
+
+        /**
+         * Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the iss of this message.
+         * See Issuer Claims and Verified Clais
+         */
+        val vc: Collection<String>? = null,
+
+        /**
+         * [**optional**] defaults to [DEFAULT_SHARE_REQ_VALIDITY_SECONDS]
+         * The validity interval of this request (not of the resulting response),
+         * measured in seconds since the moment it is issued.
+         */
+        val expiresInSeconds: Long? = DEFAULT_PERSONAL_SIGN_REQ_VALIDITY_SECONDS,
+
+
+        /**
+         * [**optional**]
+         * This can hold extra fields for the JWT payload representing the request.
+         * Use this to provide any extra fields that are not covered by the current version of the SDK
+         *
+         * The fields contained in [extras] will get overwritten by the named parameters
+         * in this class in case of a name collision.
+         */
+        val extras: Map<String, Any>? = null
+)
+
+const val DEFAULT_PERSONAL_SIGN_REQ_VALIDITY_SECONDS = 600L
+
+/**
+ * Converts a [PersonalSignRequestParams] object into a map with the required fields for JWT payload
+ */
+internal fun buildPayloadForPersonalSignReq(params: PersonalSignRequestParams): MutableMap<String, Any> {
+    val payload = params.extras.orEmpty().toMutableMap()
+
+    payload["data"] = params.data
+    params.riss?.let { payload["riss"] = it }
+    params.from?.let { payload["from"] = it }
+    params.networkId?.let { payload["net"] = it }
+    params.vc?.let { payload["vc"] = it }
+    params.callbackUrl?.let { payload["callback"] = it }
+
+    payload["type"] = JWTTypes.personalSigReq.name
+
+    return payload
+}

--- a/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
@@ -1,3 +1,5 @@
+@file:Suppress("KDocUnresolvedReference")
+
 package me.uport.sdk.credentials
 
 import android.support.annotation.Keep

--- a/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
@@ -1,7 +1,11 @@
 package me.uport.sdk.credentials
 
 import android.support.annotation.Keep
-import me.uport.sdk.credentials.RequestAccountType.*
+import me.uport.sdk.credentials.RequestAccountType.devicekey
+import me.uport.sdk.credentials.RequestAccountType.general
+import me.uport.sdk.credentials.RequestAccountType.keypair
+import me.uport.sdk.credentials.RequestAccountType.none
+import me.uport.sdk.credentials.RequestAccountType.segregated
 
 /**
  * A class that encapsulates the supported parameter types for creating a SelectiveDisclosureRequest.
@@ -43,6 +47,8 @@ class SelectiveDisclosureRequestParams(
          * The Ethereum network ID if it is relevant for this request.
          *
          * This gets encoded as `net` in the JWT payload
+         *
+         * Examples: `"0x4"`, [Networks.mainnet.networkId]
          */
         val networkId: String? = null,
 
@@ -121,7 +127,7 @@ internal fun buildPayloadForShareReq(params: SelectiveDisclosureRequestParams): 
     params.networkId?.let { payload["net"] = it }
     params.accountType?.let { payload["act"] = it.name }
 
-    payload["type"] = RequestType.shareReq.name
+    payload["type"] = JWTType.shareReq.name
 
     return payload
 }

--- a/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
@@ -68,7 +68,7 @@ class SelectiveDisclosureRequestParams(
 
         /**
          * [**optional**]
-         * A simple_list of signed claims about the issuer, usually signed by 3rd parties.
+         * A list of signed claims about the issuer, usually signed by 3rd parties.
          */
         val vc: List<String>? = null,
 
@@ -129,7 +129,7 @@ internal fun buildPayloadForShareReq(params: SelectiveDisclosureRequestParams): 
     params.networkId?.let { payload["net"] = it }
     params.accountType?.let { payload["act"] = it.name }
 
-    payload["type"] = JWTType.shareReq.name
+    payload["type"] = JWTTypes.shareReq.name
 
     return payload
 }

--- a/credentials/src/main/java/me/uport/sdk/credentials/VerifiedClaimRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/VerifiedClaimRequestParams.kt
@@ -1,0 +1,126 @@
+@file:Suppress("KDocUnresolvedReference")
+
+package me.uport.sdk.credentials
+
+/**
+ * A class that encapsulates the supported parameter types for creating a Verified Claim request.
+ *
+ * See
+ * https://github.com/uport-project/specs/blob/develop/messages/verificationreq.md
+ *
+ * The parameters in this class get encoded in the JWT that represents such a request.
+ *
+ * While the JWT can be manually constructed, this class is provided for discoverability
+ * and ease of use of frequently used params.
+ */
+class VerifiedClaimRequestParams(
+
+        /**
+         * [**required**]
+         * An unsigned claim that is requested to be signed.
+         * This should exactly match the claim of the signed Verified Claim response.
+         */
+        val unsignedClaim: Map<String, Any?>,
+
+        /**
+         * [**optional**]
+         * The DID of the identity that the claim is about
+         */
+        val sub: String? = null,
+
+        /**
+         * [**optional**]
+         * Callback URL for returning the response to a request (may be deprecated in future)
+         *
+         * This gets encoded as `callback` in the resulting JWT
+         */
+        val callbackUrl: String? = null,
+
+        /**
+         * [**optional**]
+         *
+         * The DID or URL of the audience of the JWT.
+         * The uPort app will not accept any JWT that has someone else as the audience
+         *
+         */
+        val aud: String? = null,
+
+        /**
+         * [**optional**]
+         * The DID of the identity you want to sign the Verified Claim.
+         *
+         * This can be pre-requested with a selective disclosure request
+         */
+        val riss: String? = null,
+
+        /**
+         * [**optional**]
+         * Requested expiry time in seconds
+         *
+         * TODO: clarify if this is interval or timestamp
+         */
+        val rexp: Long? = null,
+
+
+        /**
+         * [**optional**]
+         * The self signed claims for the [iss] of this message.
+         *
+         * Either as a [Map] of claim types for self signed claims eg:
+         * ```
+         * mapOf(
+         *   "name" to "Some Corp Inc",
+         *   "url" to "https://somecorp.example",
+         *   "image" to mapOf("/" to "/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB")
+         * )
+         * ```
+         * or the IPFS Hash of a JSON encoded equivalent.
+         */
+        val issc: Map<String, Any>? = null,
+
+        /**
+         * [**optional**]
+         * A collection of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the [iss] of this message.
+         * TODO: clarify what's the difference between one of the claims in [vc] and [issc]
+         */
+        val vc: Collection<String>? = null,
+
+        /**
+         * [**optional**] defaults to [DEFAULT_SHARE_REQ_VALIDITY_SECONDS]
+         * The validity interval of this request (not of the resulting response),
+         * measured in seconds since the moment it is issued.
+         */
+        val expiresInSeconds: Long? = DEFAULT_VERIFIED_CLAIM_REQ_VALIDITY_SECONDS,
+
+        /**
+         * [**optional**]
+         * This can hold extra fields for the JWT payload representing the request.
+         * Use this to provide any extra fields that are not covered by the current version of the SDK
+         *
+         * The fields contained in [extras] will get overwritten by the named parameters
+         * in this class in case of a name collision.
+         */
+        val extras: Map<String, Any>? = null
+)
+
+const val DEFAULT_VERIFIED_CLAIM_REQ_VALIDITY_SECONDS = 600L
+
+/**
+ * Converts a [VerifiedClaimRequestParams] object into a map with the required fields for JWT payload
+ */
+internal fun buildPayloadForVerifiedClaimReq(params: VerifiedClaimRequestParams): MutableMap<String, Any> {
+    val payload = params.extras.orEmpty().toMutableMap()
+
+    params.riss?.let { payload["riss"] = it }
+    params.vc?.let { payload["vc"] = it }
+    params.callbackUrl?.let { payload["callback"] = it }
+    params.sub?.let { payload["sub"] = it }
+    params.aud?.let { payload["aud"] = it }
+    params.rexp?.let { payload["rexp"] = it }
+    params.issc?.let { payload["issc"] = it }
+
+    payload["type"] = JWTTypes.verReq.name
+    payload["unsignedClaim"] = params.unsignedClaim
+
+    return payload
+}

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -78,7 +78,7 @@ class CredentialsTest {
         assert(payload.iat).isNotNull {
             it.isGreaterThanOrEqualTo(nowSeconds)
         }
-        assert(payload.type).isEqualTo(JWTType.shareReq.name)
+        assert(payload.type).isEqualTo(JWTTypes.shareReq.name)
     }
 
     @Test
@@ -111,6 +111,69 @@ class CredentialsTest {
 
         assert((load["vc"] as List<*>)).isEmpty()
 
+    }
+
+    @Test
+    fun `personal sign request payload contains relevant fields`() = runBlocking {
+
+        val params = PersonalSignRequestParams(
+                data = "sign this message",
+                callbackUrl = "myapp://get-back-to-me-with-response.url",
+                from = "0x1122334455667788990011223344556677889900",
+                riss = "did:ethr:0x1122334455667788990011223344556677889900",
+                networkId = "0x4",
+                vc = emptyList(),
+                expiresInSeconds = 1234L,
+                extras = mapOf(
+                        "hello" to "world",
+                        "type" to "expect this to be overwritten"
+                )
+        )
+
+        val load = buildPayloadForPersonalSignReq(params)
+
+        assert(load["type"]).isEqualTo("personalSigReq")
+        assert(load["data"]).isEqualTo("sign this message")
+        assert(load["callback"]).isEqualTo("myapp://get-back-to-me-with-response.url")
+        assert(load["riss"]).isEqualTo("did:ethr:0x1122334455667788990011223344556677889900")
+        assert(load["from"]).isEqualTo("0x1122334455667788990011223344556677889900")
+        assert(load["net"]).isEqualTo("0x4")
+        assert((load["vc"] as List<*>)).isEmpty()
+        assert(load["hello"]).isEqualTo("world")
+
+    }
+
+    @Test
+    fun `verified claim request payload contains relevant fields`() = runBlocking {
+
+        val params = VerifiedClaimRequestParams(
+                unsignedClaim = mapOf("name" to "John Doe"),
+                callbackUrl = "myapp://get-back-to-me-with-response.url",
+                riss = "did:ethr:0x1122334455667788990011223344556677889900",
+                rexp = 1234L,
+                aud = "did:ethr:0x9988776655443322110099887766554433221100",
+                sub = "did:ethr:0xFFEEDDCCBBAA9988776655443322110099887766",
+                issc = mapOf("dappName" to "testing"),
+                vc = emptyList(),
+                expiresInSeconds = 1234L,
+                extras = mapOf(
+                        "hello" to "world",
+                        "type" to "expect this to be overwritten"
+                )
+        )
+
+        val load = buildPayloadForVerifiedClaimReq(params)
+
+        assert(load["type"]).isEqualTo("verReq")
+        assert(load["unsignedClaim"]).isEqualTo(mapOf("name" to "John Doe"))
+        assert(load["callback"]).isEqualTo("myapp://get-back-to-me-with-response.url")
+        assert(load["riss"]).isEqualTo("did:ethr:0x1122334455667788990011223344556677889900")
+        assert((load["vc"] as List<*>)).isEmpty()
+        assert(load["hello"]).isEqualTo("world")
+        assert(load["aud"]).isEqualTo("did:ethr:0x9988776655443322110099887766554433221100")
+        assert(load["sub"]).isEqualTo("did:ethr:0xFFEEDDCCBBAA9988776655443322110099887766")
+        assert(load["issc"]).isEqualTo(mapOf("dappName" to "testing"))
+        assert(load["rexp"]).isEqualTo(1234L)
     }
 
 }

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -78,7 +78,7 @@ class CredentialsTest {
         assert(payload.iat).isNotNull {
             it.isGreaterThanOrEqualTo(nowSeconds)
         }
-        assert(payload.type).isEqualTo(RequestType.shareReq.name)
+        assert(payload.type).isEqualTo(JWTType.shareReq.name)
     }
 
     @Test

--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -4,12 +4,12 @@
     package="me.uport.sdk.demoapp">
 
     <application
+        android:name="me.uport.sdk.demoapp.DemoApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:name="me.uport.sdk.demoapp.DemoApplication"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".MainListActivity">
             <intent-filter>
@@ -37,8 +37,9 @@
         <activity android:name=".request_flows.TypedDataRequestActivity" />
 
 
-
-        <activity android:name=".DeepLinkActivity">
+        <activity
+            android:name=".DeepLinkActivity"
+            android:launchMode="singleTop">
             <!-- deep links -->
             <intent-filter
                 android:autoVerify="true"

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.uport.sdk.core.UI
-import me.uport.sdk.credentials.JWTType
+import me.uport.sdk.credentials.JWTTypes
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.transport.ResponseParser
 
@@ -34,13 +34,13 @@ class DeepLinkActivity : AppCompatActivity() {
                 val payload = withContext(Dispatchers.IO) { JWTTools().verify(token) }
                 val (_, payloadRaw, _) = JWTTools().decodeRaw(token)
 
-                val knownType = JWTType.valueOf(payload.type ?: JWTType.verResp.name)
+                val knownType = JWTTypes.valueOf(payload.type ?: JWTTypes.verResp.name)
 
                 val response = when (knownType) {
-                    JWTType.shareResp -> "name=${payload.own?.get("name")}"
-                    JWTType.personalSignResp -> "message was signed: '${payloadRaw["data"]}'"
-                    JWTType.eip712Resp -> "signature=${payloadRaw["signature"]}"
-                    JWTType.verResp -> "signed claim=${payloadRaw["claim"]}"
+                    JWTTypes.shareResp -> "name=${payload.own?.get("name")}"
+                    JWTTypes.personalSignResp -> "message was signed: '${payloadRaw["data"]}'"
+                    JWTTypes.eip712Resp -> "signature=${payloadRaw["signature"]}"
+                    JWTTypes.verResp -> "signed claim=${payloadRaw["claim"]}"
                     else -> "unknown response type"
                 }
                 """

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.uport.sdk.core.UI
+import me.uport.sdk.credentials.JWTType
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.transport.ResponseParser
 
@@ -31,14 +32,24 @@ class DeepLinkActivity : AppCompatActivity() {
                 println("got called with ${intent?.data}")
                 val token = ResponseParser.extractTokenFromIntent(intent) ?: ""
                 val payload = withContext(Dispatchers.IO) { JWTTools().verify(token) }
+                val (_, payloadRaw, _) = JWTTools().decodeRaw(token)
 
+                val knownType = JWTType.valueOf(payload.type ?: JWTType.verResp.name)
+
+                val response = when (knownType) {
+                    JWTType.shareResp -> "name=${payload.own?.get("name")}"
+                    JWTType.personalSignResp -> "message was signed: '${payloadRaw["data"]}'"
+                    JWTType.eip712Resp -> "signature=${payloadRaw["signature"]}"
+                    JWTType.verResp -> "signed claim=${payloadRaw["claim"]}"
+                    else -> "unknown response type"
+                }
                 """
                 The response we got is:
-                name=${payload?.own?.get("name")}
+                $response
 
 
                 Full JWT response is:
-                $payload
+                $payloadRaw
                 """.trimIndent()
 
             } catch (exception: RuntimeException) {

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/managing_jwt/VerifyJWTActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/managing_jwt/VerifyJWTActivity.kt
@@ -31,7 +31,7 @@ class VerifyJWTActivity : AppCompatActivity() {
                 val payload = JWTTools().verify(jwtToken)
 
                 withContext(UI) {
-                    jwtPayload.text = payload?.toString()
+                    jwtPayload.text = payload.toString()
                     progress.visibility = View.INVISIBLE
                 }
             }

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/request_flows/VerifiedClaimRequestActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/request_flows/VerifiedClaimRequestActivity.kt
@@ -9,8 +9,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.uport.sdk.core.UI
+import me.uport.sdk.credentials.Credentials
+import me.uport.sdk.credentials.VerifiedClaimRequestParams
 import me.uport.sdk.demoapp.R
-import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.transport.Transports
 
 /**
@@ -18,7 +19,6 @@ import me.uport.sdk.transport.Transports
  * This activity demonstrates the flow for creating and sending a [Verified Claim Request]
  *
  **/
-
 class VerifiedClaimRequestActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,14 +32,10 @@ class VerifiedClaimRequestActivity : AppCompatActivity() {
         val issuerDID = "did:ethr:${signer.getAddress()}"
 
         // create the request JWT payload
-        val payload = mapOf<String, Any>(
-                "callback" to "https://uport-project.github.io/uport-android-sdk",
-                "type" to "verReq",
-                "iss" to issuerDID,
-                "iat" to System.currentTimeMillis(),
-                "unsignedClaim" to mapOf(
-                        "name" to "Steve Austin"
-                )
+        val params = VerifiedClaimRequestParams(
+                unsignedClaim = mapOf("citizen of Cleverland" to true),
+                sub = issuerDID,
+                callbackUrl = "https://uport-project.github.io/uport-android-sdk"
         )
 
         request_details.text = "" +
@@ -47,7 +43,7 @@ class VerifiedClaimRequestActivity : AppCompatActivity() {
                 "\n" +
                 "Issuer DID: $issuerDID" +
                 "\n" +
-                "Unsigned Claim: ${payload["unsignedClaim"]}"
+                "Unsigned Claim: ${params.unsignedClaim}"
 
         // make request
         send_request.setOnClickListener {
@@ -55,7 +51,7 @@ class VerifiedClaimRequestActivity : AppCompatActivity() {
             progress.visibility = View.VISIBLE
 
             GlobalScope.launch {
-                val requestJWT = JWTTools().createJWT(payload, issuerDID, signer, 60 * 60)
+                val requestJWT = Credentials(issuerDID, signer).createVerificationSignatureRequest(params)
 
                 // Send a valid signed request to uport via Transports
                 @Suppress("LabeledExpression")

--- a/demoapp/src/main/res/layout/activity_deep_link.xml
+++ b/demoapp/src/main/res/layout/activity_deep_link.xml
@@ -6,16 +6,21 @@
     android:layout_height="match_parent"
     tools:context=".DeepLinkActivity">
 
-    <TextView
-        android:id="@+id/deep_link_token"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="@dimen/uport_horizontal_dialog_margin"
-        tools:text="deep link token result"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/deep_link_token"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/uport_horizontal_dialog_margin"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="deep link token result" />
+    </ScrollView>
 </android.support.constraint.ConstraintLayout>

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -178,6 +178,33 @@ class JWTTools(
         }
     }
 
+    fun decodeRaw(token: String): Triple<JwtHeader, Map<String, Any?>, ByteArray> {
+        //Split token by . from jwtUtils
+        val (encodedHeader, encodedPayload, encodedSignature) = splitToken(token)
+        if (!notEmpty(encodedHeader))
+            throw InvalidJWTException("Header cannot be empty")
+        else if (!notEmpty(encodedPayload))
+            throw InvalidJWTException("Payload cannot be empty")
+        //Decode the pieces
+        val headerString = String(encodedHeader.decodeBase64())
+        val payloadString = String(encodedPayload.decodeBase64())
+        val signatureBytes = encodedSignature.decodeBase64()
+
+        //Parse Json
+        if (headerString[0] != '{' || payloadString[0] != '{')
+            throw InvalidJWTException("Invalid JSON format, should start with {")
+        else {
+            val header = JwtHeader.fromJson(headerString)
+                    ?: throw InvalidJWTException("unable to parse the JWT header for $token")
+            val mapAdapter = moshi.mapAdapter<String, Any>(String::class.java, Any::class.java)
+
+            val payload = mapAdapter.fromJson(payloadString)
+                    ?: throw InvalidJWTException("unable to parse the JWT payload for $token")
+
+            return Triple(header, payload, signatureBytes)
+        }
+    }
+
     /**
      * Verifies a jwt [token]
      * @params jwt token
@@ -185,7 +212,7 @@ class JWTTools(
      *          when no public key matches are found in the DID document
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
      */
-    suspend fun verify(token: String): JwtPayload? {
+    suspend fun verify(token: String): JwtPayload {
         val (_, payload, signatureBytes) = decode(token)
 
         if (payload.iat != null && payload.iat > (timeProvider.nowMs() / 1000 + TIME_SKEW)) {

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -178,6 +178,11 @@ class JWTTools(
         }
     }
 
+    /**
+     * Decodes a JWT into it's 3 components, keeping the payload as a Map type
+     *
+     * This is useful for situations where the known [JwtPayload] fields are not enough.
+     */
     fun decodeRaw(token: String): Triple<JwtHeader, Map<String, Any?>, ByteArray> {
         //Split token by . from jwtUtils
         val (encodedHeader, encodedPayload, encodedSignature) = splitToken(token)

--- a/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
@@ -42,7 +42,7 @@ data class JwtPayload(
          * Also includes iss, sub, iat, exp, claim
          */
         //val claims: Map<String, Any>?, //An object containing one or more claims about sub eg: {"name":"Carol Crypteau"}
-        @Json(name = "claim") val claims: Map<String, String>? = null,
+        @Json(name = "claim") val claims: Map<String, Any>? = null,
         /**
          * Specific to Private Chain
          * Also includes dad

--- a/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
@@ -42,7 +42,7 @@ data class JwtPayload(
          * Also includes iss, sub, iat, exp, claim
          */
         //val claims: Map<String, Any>?, //An object containing one or more claims about sub eg: {"name":"Carol Crypteau"}
-        @Json(name = "claims") val claims: Map<String, String>? = null,
+        @Json(name = "claim") val claims: Map<String, String>? = null,
         /**
          * Specific to Private Chain
          * Also includes dad

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTDecodeTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTDecodeTest.kt
@@ -13,7 +13,7 @@ class JWTDecodeTest {
     private val validShareReqTokenPayload = validShareReqToken.split('.')[1]
     private val validShareReqTokenSignature = validShareReqToken.split('.')[2]
 
-    private val validVerificationToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIzNHdqc3h3dmR1YW5vN05GQzh1ak5KbkZqYmFjZ1llV0E4bSIsImlhdCI6MTQ4NTMyMTEzMywiY2xhaW1zIjp7Im5hbWUiOiJCb2IiLCJnZW5kZXIiOiJtYWxlIn0sImV4cCI6MTQ4NTQwNzUzM30.orxkk0gzk0URvAkMM2vNzgW7IRefDCKhfyM9oP4Ye3GhuXko0h4TDMggslS_eIETqrRAqfG4XmcHIX9C-S8DoA"
+    private val validVerificationToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjbGFpbSI6eyJuYW1lIjoiQm9iIiwiZ2VuZGVyIjoibWFsZSJ9LCJpYXQiOjE1NDk5MDg0MjQsImV4cCI6MTU0OTkwODcyNCwiaXNzIjoiZGlkOmV0aHI6MHhjZjAzZGQwYTg5NGVmNzljYjViNjAxYTQzYzRiMjVlM2FlNGM2N2VkIn0.ffjGFzoSfX-fS50GHhYkwA8It5034Rw8BczWslUcbfGI51uJSGbmhfJSfeGdEaPlFFgVrnRj1YBoG_oHrnEiBQA"
 
     private val invalidTokenOnlyHeader = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ."
     private val invalidTokenEmptyPayload = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ..C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ"
@@ -56,7 +56,7 @@ class JWTDecodeTest {
         val nameClaim = mapOf("name" to "Bob", "gender" to "male")
         assert(header.typ).isEqualTo("JWT")
         assert(payload.claims).isEqualTo(nameClaim)
-        assert(payload.iss).isEqualTo("34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m")
+        assert(payload.iss).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
     }
 
     @Test


### PR DESCRIPTION
### Goal

A dev building a mobile frontend that interacts with the uPort mobile app should be able to easily create requests using self documenting abstractions instead of crafting JWTs by hand.

### Changes

* `Credentials` object exposes method to build a  `verificationSignatureRequest()` and `createPersonalSignRequest()`
* parameters needed for such a request should be represented by specific data types with blank default values corresponding to the optional parameters
* sample app shows the use of these abstractions in the request flows menu (verification and personal sign submenus)

### Testing

As usual, `./gradlew test cC --no-parallel` should go through the whole testsuite.
In this case successful compilation of the sampleapp is also part of the test since the request parameters data types require the obligatory fields.

This PR fixes https://www.pivotaltracker.com/story/show/160661834
This PR fixes https://www.pivotaltracker.com/story/show/163908002
