### PR TITLE
Verifier Algorithm

### DIFF
--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -34,7 +34,7 @@ class DeepLinkActivity : AppCompatActivity() {
                 val payload = withContext(Dispatchers.IO) { JWTTools().verify(token) }
                 val (_, payloadRaw, _) = JWTTools().decodeRaw(token)
 
-                val knownType = JWTTypes.valueOf(payload!!.type ?: JWTTypes.verResp.name)
+                val knownType = JWTTypes.valueOf(payload.type ?: JWTTypes.verResp.name)
 
                 val response = when (knownType) {
                     JWTTypes.shareResp -> "name=${payload.own?.get("name")}"

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/DeepLinkActivity.kt
@@ -34,7 +34,7 @@ class DeepLinkActivity : AppCompatActivity() {
                 val payload = withContext(Dispatchers.IO) { JWTTools().verify(token) }
                 val (_, payloadRaw, _) = JWTTools().decodeRaw(token)
 
-                val knownType = JWTTypes.valueOf(payload.type ?: JWTTypes.verResp.name)
+                val knownType = JWTTypes.valueOf(payload!!.type ?: JWTTypes.verResp.name)
 
                 val response = when (knownType) {
                     JWTTypes.shareResp -> "name=${payload.own?.get("name")}"

--- a/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
@@ -1,0 +1,148 @@
+package me.uport.sdk.jwt
+
+import com.uport.sdk.signer.getUncompressedPublicKeyWithPrefix
+import org.kethereum.crypto.CURVE
+import org.kethereum.crypto.model.PublicKey
+import org.kethereum.hashes.sha256
+import org.kethereum.model.SignatureData
+import org.spongycastle.asn1.x9.X9IntegerConverter
+import org.spongycastle.crypto.digests.SHA256Digest
+import org.spongycastle.crypto.params.ECDomainParameters
+import org.spongycastle.crypto.params.ECPublicKeyParameters
+import org.spongycastle.crypto.signers.ECDSASigner
+import org.spongycastle.crypto.signers.HMacDSAKCalculator
+import org.spongycastle.math.ec.ECAlgorithms
+import org.spongycastle.math.ec.ECPoint
+import org.spongycastle.math.ec.custom.sec.SecP256K1Curve
+import java.math.BigInteger
+import java.security.SignatureException
+
+private val DOMAIN_PARAMS = CURVE.run { ECDomainParameters(curve, g, n, h) }
+
+internal data class ECDSASignature internal constructor(val r: BigInteger, val s: BigInteger)
+
+/**
+ * This method matches the [messageHash] and its [signature] against a given [publicKey]
+ * on the secp256k1 elliptic curve
+ *
+ * @param messageHash The hash of the message. For JWT this is `sha256`, for ETH this is `keccak`
+ * @param signature the components of the signature. Only `r` and `s` are used for verification, the `v` component is ignored
+ * @param publicKey the public key to check against.
+ *
+ * @return `true` when there is a match or `false` otherwise
+ */
+internal fun ecVerify(messageHash: ByteArray, signature: SignatureData, publicKey: PublicKey): Boolean {
+    val publicKeyBytes = publicKey.getUncompressedPublicKeyWithPrefix()
+
+    val ecPoint = CURVE.curve.decodePoint(publicKeyBytes)
+
+    val verifier = ECDSASigner(HMacDSAKCalculator(SHA256Digest()))
+
+    val ecPubKeyParams = ECPublicKeyParameters(ecPoint, DOMAIN_PARAMS)
+    verifier.init(false, ecPubKeyParams)
+
+    return verifier.verifySignature(messageHash, signature.r, signature.s)
+}
+
+/***
+ * Copied from Kethereum because it is a private method there
+ */
+internal fun recoverFromSignature(recId: Int, sig: ECDSASignature, messageHash: ByteArray?): BigInteger? {
+    require(recId >= 0) { "recId must be positive" }
+    require(sig.r.signum() >= 0) { "r must be positive" }
+    require(sig.s.signum() >= 0) { "s must be positive" }
+    require(messageHash != null) { "message cannot be null" }
+
+    // 1.0 For j from 0 to h   (h == recId here and the loop is outside this function)
+    //   1.1 Let x = r + jn
+    val n = CURVE.n  // Curve order.
+    val i = BigInteger.valueOf(recId.toLong() / 2)
+    val x = sig.r.add(i.multiply(n))
+    //   1.2. Convert the integer x to an octet string X of length mlen using the conversion
+    //        routine specified in Section 2.3.7, where mlen = ⌈(log2 p)/8⌉ or mlen = ⌈m/8⌉.
+    //   1.3. Convert the octet string (16 set binary digits)||X to an elliptic curve point R
+    //        using the conversion routine specified in Section 2.3.4. If this conversion
+    //        routine outputs “invalid”, then do another iteration of Step 1.
+    //
+    // More concisely, what these points mean is to use X as a compressed public key.
+    val prime = SecP256K1Curve.q
+    if (x >= prime) {
+        // Cannot have point co-ordinates larger than this as everything takes place modulo Q.
+        return null
+    }
+    // Compressed keys require you to know an extra bit of data about the y-coord as there are
+    // two possibilities. So it'DEFAULT_REGISTRY_ADDRESS encoded in the recId.
+    val r = decompressKey(x, recId and 1 == 1)
+    //   1.4. If nR != point at infinity, then do another iteration of Step 1 (callers
+    //        responsibility).
+    if (!r.multiply(n).isInfinity) {
+        return null
+    }
+    //   1.5. Compute e from M using Steps 2 and 3 of ECDSA signature verification.
+    val e = BigInteger(1, messageHash)
+    //   1.6. For k from 1 to 2 do the following.   (loop is outside this function via
+    //        iterating recId)
+    //   1.6.1. Compute a candidate public key as:
+    //               Q = mi(r) * (sR - eG)
+    //
+    // Where mi(x) is the modular multiplicative inverse. We transform this into the following:
+    //               Q = (mi(r) * DEFAULT_REGISTRY_ADDRESS ** R) + (mi(r) * -e ** G)
+    // Where -e is the modular additive inverse of e, that is z such that z + e = 0 (mod n).
+    // In the above equation ** is point multiplication and + is point addition (the EC group
+    // operator).
+    //
+    // We can find the additive inverse by subtracting e from zero then taking the mod. For
+    // example the additive inverse of 3 modulo 11 is 8 because 3 + 8 mod 11 = 0, and
+    // -3 mod 11 = 8.
+    val eInv = BigInteger.ZERO.subtract(e).mod(n)
+    val rInv = sig.r.modInverse(n)
+    val srInv = rInv.multiply(sig.s).mod(n)
+    val eInvrInv = rInv.multiply(eInv).mod(n)
+    val q = ECAlgorithms.sumOfTwoMultiplies(CURVE.g, eInvrInv, r, srInv)
+
+    val qBytes = q.getEncoded(false)
+    // We remove the prefix
+    return BigInteger(1, qBytes.copyOfRange(1, qBytes.size))
+}
+
+/**
+ * This function is taken from Kethereum
+ * Decompress a compressed public key (x-coord and low-bit of y-coord).
+ * */
+private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
+    val x9 = X9IntegerConverter()
+    val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))
+    compEnc[0] = (if (yBit) 0x03 else 0x02).toByte()
+    return CURVE.curve.decodePoint(compEnc)
+}
+
+/**
+ * This Function is adapted from the Kethereum implementation
+ * Given an arbitrary piece of text and an Ethereum message signature encoded in bytes,
+ * returns the public key that was used to sign it. This can then be compared to the expected
+ * public key to determine if the signature was correct.
+ *
+ * @param message the data that was signed
+ * @param signatureData The recoverable signature components
+ * @return the public key used to sign the message
+ * @throws SignatureException If the public key could not be recovered or if there was a
+ * signature format error.
+ */
+@Throws(SignatureException::class)
+fun signedJwtToKey(message: ByteArray, signatureData: SignatureData): BigInteger {
+
+    val header = signatureData.v
+    // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
+    //                  0x1D = second key with even y, 0x1E = second key with odd y
+    if (header < 27 || header > 34) {
+        throw SignatureException("Header byte out of range: $header")
+    }
+
+    val sig = ECDSASignature(signatureData.r, signatureData.s)
+
+    val messageHash = message.sha256()
+    val recId = header - 27
+    return recoverFromSignature(recId, sig, messageHash)
+            ?: throw SignatureException("Could not recover public key from signature")
+}
+

--- a/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
@@ -110,7 +110,7 @@ internal fun recoverFromSignature(recId: Int, sig: ECDSASignature, messageHash: 
  * Decompress a compressed public key (x-coord and low-bit of y-coord).
  * */
 @Suppress("CommentOverPrivateFunction")
-fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
+private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
     val x9 = X9IntegerConverter()
     val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))
     compEnc[0] = (if (yBit) 0x03 else 0x02).toByte()

--- a/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
@@ -109,6 +109,7 @@ internal fun recoverFromSignature(recId: Int, sig: ECDSASignature, messageHash: 
  * This function is taken from Kethereum
  * Decompress a compressed public key (x-coord and low-bit of y-coord).
  * */
+@Suppress("CommentOverPrivateFunction")
 private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
     val x9 = X9IntegerConverter()
     val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))

--- a/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
@@ -110,7 +110,7 @@ internal fun recoverFromSignature(recId: Int, sig: ECDSASignature, messageHash: 
  * Decompress a compressed public key (x-coord and low-bit of y-coord).
  * */
 @Suppress("CommentOverPrivateFunction")
-private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
+fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
     val x9 = X9IntegerConverter()
     val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))
     compEnc[0] = (if (yBit) 0x03 else 0x02).toByte()

--- a/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/ECUtils.kt
@@ -109,7 +109,6 @@ internal fun recoverFromSignature(recId: Int, sig: ECDSASignature, messageHash: 
  * This function is taken from Kethereum
  * Decompress a compressed public key (x-coord and low-bit of y-coord).
  * */
-@Suppress("CommentOverPrivateFunction")
 private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
     val x9 = X9IntegerConverter()
     val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -37,6 +37,7 @@ import org.walleth.khex.clean0xPrefix
 import org.walleth.khex.hexToByteArray
 import java.math.BigInteger
 import java.security.InvalidAlgorithmParameterException
+import java.security.SignatureException
 
 /**
  * Tools for Verifying, Creating, and Decoding uport JWTs
@@ -265,7 +266,7 @@ class JWTTools(
 
         val recoveredPubKey: BigInteger = try {
             signedJwtToKey(signingInputBytes, sigData)
-        } catch (e: Exception) {
+        } catch (e: SignatureException) {
             BigInteger.ZERO
         }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -272,7 +272,6 @@ class JWTTools(
         val pubKeyNoPrefix = PublicKey(recoveredPubKey).normalize()
         val recoveredAddress = pubKeyNoPrefix.toAddress().cleanHex.toLowerCase()
 
-        //TODO: this check needs to be adapted to the logic from [did-jwt](https://github.com/uport-project/did-jwt/blob/3ea977934e844598b2bc6576369335fd1972a12a/src/JWT.js#L118)
         val matches = publicKeys.map { pubKeyEntry ->
 
             val pkBytes = pubKeyEntry.publicKeyHex?.hexToByteArray()
@@ -285,8 +284,6 @@ class JWTTools(
 
         }.filter { ethereumAddress ->
 
-            //this method of validation only works for uPort style JWTs, where the publicKeys
-            // can be converted to ethereum addresses
             ethereumAddress.toLowerCase() == recoveredAddress
         }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -2,8 +2,17 @@ package me.uport.sdk.jwt
 
 import android.content.Context
 import com.squareup.moshi.JsonAdapter
-import com.uport.sdk.signer.*
-import me.uport.sdk.core.*
+import com.uport.sdk.signer.Signer
+import com.uport.sdk.signer.UportHDSigner
+import com.uport.sdk.signer.decodeJose
+import com.uport.sdk.signer.getJoseEncoded
+import com.uport.sdk.signer.normalize
+import me.uport.sdk.core.ITimeProvider
+import me.uport.sdk.core.Networks
+import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.toBase64
+import me.uport.sdk.core.toBase64UrlSafe
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.httpsdid.HttpsDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
@@ -17,23 +26,15 @@ import me.uport.sdk.universaldid.DelegateType
 import me.uport.sdk.universaldid.PublicKeyEntry
 import me.uport.sdk.universaldid.UniversalDID
 import me.uport.sdk.uportdid.UportDIDResolver
-import org.kethereum.crypto.CURVE
 import org.kethereum.crypto.model.PUBLIC_KEY_SIZE
 import org.kethereum.crypto.model.PublicKey
 import org.kethereum.crypto.toAddress
 import org.kethereum.encodings.decodeBase58
 import org.kethereum.extensions.toBigInteger
-import org.kethereum.hashes.sha256
-import org.kethereum.model.SignatureData
-import org.spongycastle.asn1.x9.X9IntegerConverter
-import org.spongycastle.math.ec.ECAlgorithms
-import org.spongycastle.math.ec.ECPoint
-import org.spongycastle.math.ec.custom.sec.SecP256K1Curve
 import org.walleth.khex.clean0xPrefix
 import org.walleth.khex.hexToByteArray
 import java.math.BigInteger
 import java.security.InvalidAlgorithmParameterException
-import java.security.SignatureException
 
 /**
  * Tools for Verifying, Creating, and Decoding uport JWTs
@@ -245,7 +246,7 @@ class JWTTools(
     }
 
     private fun verifyES256K(publicKeys: List<PublicKeyEntry>, signatureBytes: ByteArray): Boolean {
-        return true
+        throw TODO("not implemented yet. this should use the ecVerify method to check the list of publicKeys")
     }
 
     fun verifyRecoverableES256K(publicKeys: List<PublicKeyEntry>, signatureBytes: ByteArray, signingInputBytes: ByteArray): Boolean {
@@ -316,107 +317,7 @@ class JWTTools(
         return authenticators
     }
 
-    /***
-     * Copied from Kethereum because it is a private method there
-     */
-    private fun recoverFromSignature(recId: Int, sig: ECDSASignature, message: ByteArray?): BigInteger? {
-        require(recId >= 0) { "recId must be positive" }
-        require(sig.r.signum() >= 0) { "r must be positive" }
-        require(sig.s.signum() >= 0) { "s must be positive" }
-        require(message != null) { "message cannot be null" }
 
-        // 1.0 For j from 0 to h   (h == recId here and the loop is outside this function)
-        //   1.1 Let x = r + jn
-        val n = CURVE.n  // Curve order.
-        val i = BigInteger.valueOf(recId.toLong() / 2)
-        val x = sig.r.add(i.multiply(n))
-        //   1.2. Convert the integer x to an octet string X of length mlen using the conversion
-        //        routine specified in Section 2.3.7, where mlen = ⌈(log2 p)/8⌉ or mlen = ⌈m/8⌉.
-        //   1.3. Convert the octet string (16 set binary digits)||X to an elliptic curve point R
-        //        using the conversion routine specified in Section 2.3.4. If this conversion
-        //        routine outputs “invalid”, then do another iteration of Step 1.
-        //
-        // More concisely, what these points mean is to use X as a compressed public key.
-        val prime = SecP256K1Curve.q
-        if (x >= prime) {
-            // Cannot have point co-ordinates larger than this as everything takes place modulo Q.
-            return null
-        }
-        // Compressed keys require you to know an extra bit of data about the y-coord as there are
-        // two possibilities. So it'DEFAULT_REGISTRY_ADDRESS encoded in the recId.
-        val r = decompressKey(x, recId and 1 == 1)
-        //   1.4. If nR != point at infinity, then do another iteration of Step 1 (callers
-        //        responsibility).
-        if (!r.multiply(n).isInfinity) {
-            return null
-        }
-        //   1.5. Compute e from M using Steps 2 and 3 of ECDSA signature verification.
-        val e = BigInteger(1, message)
-        //   1.6. For k from 1 to 2 do the following.   (loop is outside this function via
-        //        iterating recId)
-        //   1.6.1. Compute a candidate public key as:
-        //               Q = mi(r) * (sR - eG)
-        //
-        // Where mi(x) is the modular multiplicative inverse. We transform this into the following:
-        //               Q = (mi(r) * DEFAULT_REGISTRY_ADDRESS ** R) + (mi(r) * -e ** G)
-        // Where -e is the modular additive inverse of e, that is z such that z + e = 0 (mod n).
-        // In the above equation ** is point multiplication and + is point addition (the EC group
-        // operator).
-        //
-        // We can find the additive inverse by subtracting e from zero then taking the mod. For
-        // example the additive inverse of 3 modulo 11 is 8 because 3 + 8 mod 11 = 0, and
-        // -3 mod 11 = 8.
-        val eInv = BigInteger.ZERO.subtract(e).mod(n)
-        val rInv = sig.r.modInverse(n)
-        val srInv = rInv.multiply(sig.s).mod(n)
-        val eInvrInv = rInv.multiply(eInv).mod(n)
-        val q = ECAlgorithms.sumOfTwoMultiplies(CURVE.g, eInvrInv, r, srInv)
-
-        val qBytes = q.getEncoded(false)
-        // We remove the prefix
-        return BigInteger(1, qBytes.copyOfRange(1, qBytes.size))
-    }
-
-    /**
-     * This function is taken from Kethereum
-     * Decompress a compressed public key (x co-ord and low-bit of y-coord).
-     * */
-    private fun decompressKey(xBN: BigInteger, yBit: Boolean): ECPoint {
-        val x9 = X9IntegerConverter()
-        val compEnc = x9.integerToBytes(xBN, 1 + x9.getByteLength(CURVE.curve))
-        compEnc[0] = (if (yBit) 0x03 else 0x02).toByte()
-        return CURVE.curve.decodePoint(compEnc)
-    }
-
-    /**
-     * This Function is adapted from the Kethereum implementation
-     * Given an arbitrary piece of text and an Ethereum message signature encoded in bytes,
-     * returns the public key that was used to sign it. This can then be compared to the expected
-     * public key to determine if the signature was correct.
-     *
-     * @param message RLP encoded message.
-     * @param signatureData The message signature components
-     * @return the public key used to sign the message
-     * @throws SignatureException If the public key could not be recovered or if there was a
-     * signature format error.
-     */
-    @Throws(SignatureException::class)
-    fun signedJwtToKey(message: ByteArray, signatureData: SignatureData): BigInteger {
-
-        val header = signatureData.v
-        // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
-        //                  0x1D = second key with even y, 0x1E = second key with odd y
-        if (header < 27 || header > 34) {
-            throw SignatureException("Header byte out of range: $header")
-        }
-
-        val sig = ECDSASignature(signatureData.r, signatureData.s)
-
-        val messageHash = message.sha256()
-        val recId = header - 27
-        return recoverFromSignature(recId, sig, messageHash)
-                ?: throw SignatureException("Could not recover public key from signature")
-    }
 
     companion object {
         //Create adapters with each object
@@ -432,4 +333,3 @@ class JWTTools(
 
 }
 
-private data class ECDSASignature internal constructor(val r: BigInteger, val s: BigInteger)

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -213,7 +213,7 @@ class JWTTools(
      *          when no public key matches are found in the DID document
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
      */
-    suspend fun verify(token: String, auth: Boolean = false): JwtPayload? {
+    suspend fun verify(token: String, auth: Boolean = false): JwtPayload {
         val (header, payload, signatureBytes) = decode(token)
 
         if (payload.iat != null && payload.iat > (timeProvider.nowMs() / 1000 + TIME_SKEW)) {

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -2,8 +2,17 @@ package me.uport.sdk.jwt
 
 import android.content.Context
 import com.squareup.moshi.JsonAdapter
-import com.uport.sdk.signer.*
-import me.uport.sdk.core.*
+import com.uport.sdk.signer.Signer
+import com.uport.sdk.signer.UportHDSigner
+import com.uport.sdk.signer.decodeJose
+import com.uport.sdk.signer.getJoseEncoded
+import com.uport.sdk.signer.normalize
+import me.uport.sdk.core.ITimeProvider
+import me.uport.sdk.core.Networks
+import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.core.decodeBase64
+import me.uport.sdk.core.toBase64
+import me.uport.sdk.core.toBase64UrlSafe
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.httpsdid.HttpsDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
@@ -22,6 +31,7 @@ import org.kethereum.crypto.model.PublicKey
 import org.kethereum.crypto.toAddress
 import org.kethereum.encodings.decodeBase58
 import org.kethereum.extensions.toBigInteger
+import org.kethereum.hashes.sha256
 import org.kethereum.model.SignatureData
 import org.walleth.khex.clean0xPrefix
 import org.walleth.khex.hexToByteArray
@@ -233,6 +243,8 @@ class JWTTools(
 
     private fun verifyES256K(publicKeys: List<PublicKeyEntry>, sigData: SignatureData, signingInputBytes: ByteArray): Boolean {
 
+        val messageHash = signingInputBytes.sha256()
+
         val matches = publicKeys.map { pubKeyEntry ->
 
             val pkBytes = pubKeyEntry.publicKeyHex?.hexToByteArray()
@@ -243,7 +255,7 @@ class JWTTools(
 
         }.filter { publicKey ->
 
-            ecVerify(signingInputBytes, sigData, publicKey)
+            ecVerify(messageHash, sigData, publicKey)
         }
 
         return matches.isNotEmpty()

--- a/jwt/src/test/java/me/uport/sdk/jwt/ECUtilsKtTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/ECUtilsKtTest.kt
@@ -1,0 +1,31 @@
+package me.uport.sdk.jwt
+
+import assertk.assert
+import assertk.assertions.isTrue
+import org.junit.Test
+import org.kethereum.crypto.model.PrivateKey
+import org.kethereum.crypto.publicKeyFromPrivate
+import org.kethereum.extensions.hexToBigInteger
+import org.kethereum.hashes.sha256
+import org.kethereum.model.SignatureData
+
+class ECUtilsKtTest {
+
+    @Test
+    fun `can verify non recoverable JWT signature`() {
+
+        val referencePayload = "Hello, world!".toByteArray()
+
+        val referenceSignature = SignatureData(
+                r = "6bcd81446183af193ca4a172d5c5c26345903b24770d90b5d790f74a9dec1f68".hexToBigInteger(),
+                s = "e2b85b3c92c9b4f3cf58de46e7997d8efb6e14b2e532d13dfa22ee02f3a43d5d".hexToBigInteger()
+        )
+
+        val privateKey = PrivateKey("65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960".hexToBigInteger())
+        val publicKey = publicKeyFromPrivate(privateKey)
+
+        val messageHash = referencePayload.sha256()
+        val result = ecVerify(messageHash, referenceSignature, publicKey)
+        assert(result).isTrue()
+    }
+}

--- a/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
@@ -16,8 +16,6 @@ class KeyRecoveryTest {
     //  Uncomment `@Test` to iterate over 1000 * 1000 key/message combinations. Takes a lot of time.
     //@Test
     fun `can recover key from JWT signature`() = runBlocking {
-        val tools = JWTTools()
-
         for (i in 0 until 1000) {
             val privateKey = "super secret $i".toByteArray().sha256().toHexString()
             val pubKey = publicKeyFromPrivate(PrivateKey(privateKey.hexToBigInteger())).key.toHexStringNoPrefix()
@@ -28,7 +26,7 @@ class KeyRecoveryTest {
 
                 val sigData = signer.signJWT(message)
 
-                val recovered = tools.signedJwtToKey(message, sigData).toHexStringNoPrefix()
+                val recovered = signedJwtToKey(message, sigData).toHexStringNoPrefix()
 
                 assertEquals("failed at key $i, message $j", pubKey, recovered)
             }

--- a/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
@@ -85,12 +85,27 @@ fun unpackCiphertext(ciphertext: String): List<ByteArray> =
                 .split(DELIMITER)
                 .map { it.decodeBase64() }
 
+/**
+ * Decompresses the public key of this pair and returns the uncompressed version, including prefix
+ */
 fun ECKeyPair.getUncompressedPublicKeyWithPrefix(): ByteArray {
-    val pubBytes = this.publicKey.key.toBytesPadded(UportSigner.UNCOMPRESSED_PUBLIC_KEY_SIZE)
+    val pubBytes = this.publicKey.normalize().key.toBytesPadded(UportSigner.UNCOMPRESSED_PUBLIC_KEY_SIZE)
     pubBytes[0] = 0x04
     return pubBytes
 }
 
+/**
+ * Returns the uncompressed version of this publicKey, including prefix
+ */
+fun PublicKey.getUncompressedPublicKeyWithPrefix(): ByteArray {
+    val pubBytes = this.normalize().key.toBytesPadded(UportSigner.UNCOMPRESSED_PUBLIC_KEY_SIZE)
+    pubBytes[0] = 0x04
+    return pubBytes
+}
+
+/**
+ * Transforms a PublicKey into its normalized version which is decompressed and has no prefix
+ */
 fun PublicKey.normalize(): PublicKey {
     val pubBytes = this.key.toByteArray()
     val normalizedBytes = when (pubBytes.size) {
@@ -101,9 +116,15 @@ fun PublicKey.normalize(): PublicKey {
     return PublicKey(normalizedBytes.toBigInteger())
 }
 
+/**
+ * represents a BigInteger as a base64 encoding of a fixed size bytearray. The [keySize] defaults to 32 bytes (the size of a private key)
+ */
 fun BigInteger.keyToBase64(keySize: Int = PRIVATE_KEY_SIZE): String =
         this.toBytesPadded(keySize).toBase64().padBase64()
 
+/**
+ * shorthand for checking if this code is running on android M or later
+ */
 fun hasMarshmallow(): Boolean = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
 
 typealias EncryptionCallback = (err: Exception?, ciphertext: String) -> Unit


### PR DESCRIPTION
### Goal
Verify JWTs different based on the header algorithm

### Changes
- Use the filtered list of public keys from `resolveAuthenticator` instead of using the list of keys directly from the `DIDDocument` 
- Added two new methods `verifyRecoverableES256K()` and `verifyES256K` in `JWTTools`. 

### Testing
Run test suite using `./gradlew test cC --no-parallel`

Note: This task is branched out from `feature/163328062-resolve-authenticator`
