### PR TITLE
Create a signed claim about a user 

### DIFF
--- a/credentials/build.gradle
+++ b/credentials/build.gradle
@@ -48,4 +48,5 @@ dependencies {
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
+    testImplementation project(":test-helpers")
 }

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -120,6 +120,32 @@ class Credentials(
 
 
     /**
+     * Creates a JWT with a signed claim about a subject.
+     *
+     * @param sub **REQUIRED** a valid DID for the subject of credential
+     * @param claim **REQUIRED** claim about subject single key value or key mapping to object with multiple values
+     * @param callbackUrk **REQUIRED** a map detailing the payload of the resulting JWT
+     * @param expiresInSeconds **OPTIONAL** number of seconds of validity of the claim.
+     * @param verifiedClaims **OPTIONAL** verified claims about the subject, single key value or key mapping to object with multiple values
+     *
+     *  ```
+     */
+    suspend fun createVerification(sub: String,
+                                   claim: Map<String, Any>,
+                                   callbackUrl: String,
+                                   verifiedClaims: Map<String, Any>?,
+                                   expiresInSeconds: Long?): String {
+
+        val payload = mutableMapOf<String, Any>()
+        payload["sub"] = sub
+        payload["claim"] = claim
+        payload["vc"] = verifiedClaims ?: emptyMap<String, Any>()
+        payload["callback"] = callbackUrl
+        return this.signJWT(payload, expiresInSeconds ?: 600L)
+    }
+
+
+    /**
      *  Creates a JWT using the given [payload], issued and signed using the [did] and [signer]
      *  fields of this [Credentials] instance.
      *

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -133,7 +133,7 @@ class Credentials(
     suspend fun createVerification(sub: String,
                                    claim: Map<String, Any>,
                                    callbackUrl: String? = null,
-                                   verifiedClaims: Map<String, Any>?,
+                                   verifiedClaims: Collection<String>? = null,
                                    expiresInSeconds: Long?): String {
 
         val payload = mutableMapOf<String, Any>()

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -120,13 +120,15 @@ class Credentials(
 
 
     /**
-     * Creates a JWT with a signed claim about a subject.
+     * Creates a JWT with a signed claim.
      *
      * @param sub **REQUIRED** a valid DID for the subject of credential
-     * @param claim **REQUIRED** claim about subject single key value or key mapping to object with multiple values
-     * @param callbackUrk **REQUIRED** a map detailing the payload of the resulting JWT
+     * @param claim **REQUIRED** claim about subject single key value or key mapping
+     *              to object with multiple values
+     * @param callbackUrl **OPTIONAL** the URL that receives the response
      * @param expiresInSeconds **OPTIONAL** number of seconds of validity of the claim.
-     * @param verifiedClaims **OPTIONAL** verified claims about the subject, single key value or key mapping to object with multiple values
+     * @param verifiedClaims **OPTIONAL** a list of verified claims which can be about anything
+ *                          related to the claim and in most cases it is related to the issuer
      *
      *  ```
      */
@@ -134,13 +136,13 @@ class Credentials(
                                    claim: Map<String, Any>,
                                    callbackUrl: String? = null,
                                    verifiedClaims: Collection<String>? = null,
-                                   expiresInSeconds: Long?): String {
+                                   expiresInSeconds: Long? = 600L): String {
 
         val payload = mutableMapOf<String, Any>()
         payload["sub"] = sub
         payload["claim"] = claim
-        payload["vc"] = verifiedClaims ?: emptyMap<String, Any>()
-        payload["callback"] = callbackUrl
+        payload["vc"] = verifiedClaims ?: emptyList<String>()
+        payload["callback"] = callbackUrl ?: ""
         return this.signJWT(payload, expiresInSeconds ?: 600L)
     }
 

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -132,7 +132,7 @@ class Credentials(
      */
     suspend fun createVerification(sub: String,
                                    claim: Map<String, Any>,
-                                   callbackUrl: String,
+                                   callbackUrl: String? = null,
                                    verifiedClaims: Map<String, Any>?,
                                    expiresInSeconds: Long?): String {
 

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -59,15 +59,18 @@ class CredentialsTest {
     @Test
     fun `create verification test with all params`() = runBlocking {
 
-        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6eyJlZHVjYXRpb24iOiJNYXN0ZXJzIiwicHJvZmVzc2lvbiI6IkludmVzdG1lbnQgQmFua2VyIiwicGFzc29ydCI6IkdFMzQ1OEpDIn0sImNhbGxiYWNrIjoibXlhcHA6Ly9nZXQtYmFjay10by1tZS13aXRoLXJlc3BvbnNlLnVybCIsImlhdCI6MTIzNDU2NzgsImV4cCI6MTIzNDg2NzgsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.nHJXDYJnTj9QBjN90VTqJOzpcldNmeZ_BMTB3ZPeDbwY9Q99iHF1P-yQGRQF7efG-WOQYsdhfpcSle5kEDQ4cg"
+        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6WyJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUprYVdRNlpYUm9jam93ZUdZelltVmhZek13WXpRNU9HUTVaVEkyT0RZMVpqTTBabU5oWVRVM1pHSmlPVE0xWWpCa056UWlMQ0psWkhWallYUnBiMjRpT2lKTllYTjBaWEp6SWl3aWFXRjBJam94TlRFMk1qTTVNREl5ZlEud1RuUGhnTWJyU2xyV2NmUjdfX3hXYmxHLUEzbmdqTFQyYlBfTTdaOW1pWSIsImV5SmhiR2NpT2lKSVV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUp6ZFdJaU9pSmthV1E2WlhSb2Nqb3dlR1l6WW1WaFl6TXdZelE1T0dRNVpUSTJPRFkxWmpNMFptTmhZVFUzWkdKaU9UTTFZakJrTnpRaUxDSnNiMk5oZEdsdmJpSTZJbFJsZUdGeklpd2lhV0YwSWpveE5URTJNak01TURJeWZRLk8yb3FZNHBnbUFtV3FlT3Q3NlBUaUIzeTlqRUdmMlphWEVoSVJlTTlJTFUiXSwiY2FsbGJhY2siOiJteWFwcDovL2dldC1iYWNrLXRvLW1lLXdpdGgtcmVzcG9uc2UudXJsIiwiaWF0IjoxMjM0NTY3OCwiZXhwIjoxMjM0ODY3OCwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.aGy68_dqtXBi65MuDdwlVUHxJ4kBV_TjbHVKDPbyzYWyW-hCbBkO7AqLo3zN4ToiSOSZiWel4hl6p0HIBU9Hnw"
 
-        val claim = mapOf("name" to "John Doe",
+        val claim = mapOf(
+                "name" to "John Doe",
                 "age" to "35",
-                "location" to "Germany")
+                "location" to "Germany"
+        )
 
-        val vc = mapOf("education" to "Masters",
-                "profession" to "Investment Banker",
-                "passort" to "GE3458JC")
+        val vc = listOf(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJlZHVjYXRpb24iOiJNYXN0ZXJzIiwiaWF0IjoxNTE2MjM5MDIyfQ.wTnPhgMbrSlrWcfR7__xWblG-A3ngjLT2bP_M7Z9miY",
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU"
+        )
 
         val timeProvider = TestTimeProvider(12345678000L)
 
@@ -79,15 +82,13 @@ class CredentialsTest {
                 vc,
                 3000L
         )
-
         assert(jwt).isEqualTo(expectedJWT)
-
     }
 
     @Test
     fun `create verification test with required params only`() = runBlocking {
 
-        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6e30sImNhbGxiYWNrIjoibXlhcHA6Ly9nZXQtYmFjay10by1tZS13aXRoLXJlc3BvbnNlLnVybCIsImlhdCI6MTIzNDU2NzgsImV4cCI6MTIzNDYyNzgsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.Z0rachvLJzskxGJMuV8KwQDbMZE0mrvNbaTMQ5KgwiPFLDlpa7QtvuYQrCqcnLwfPpvWrHwrBLjgQsa8D_g8LA"
+        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6W10sImNhbGxiYWNrIjoiIiwiaWF0IjoxMjM0NTY3OCwiZXhwIjoxMjM0NjI3OCwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.C5sY_WCnSjYmqX-w3NZo9AmB6qVUy-Uwd6Fzz24CtbK0JWAYxgslqr6-JYjkB5O5Eu9IJYNS-1pKH-waNGGwmA"
 
         val claim = mapOf("name" to "John Doe",
                 "age" to "35",
@@ -96,16 +97,9 @@ class CredentialsTest {
         val timeProvider = TestTimeProvider(12345678000L)
 
         val cred = Credentials("did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX", KPSigner("0x1234"), timeProvider)
-        val jwt = cred.createVerification(
-                "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
-                claim,
-                "myapp://get-back-to-me-with-response.url",
-                null,
-                null
-        )
+        val jwt = cred.createVerification("did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74", claim)
 
         assert(jwt).isEqualTo(expectedJWT)
-
     }
 
     @Test

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -11,6 +11,7 @@ import me.uport.sdk.core.SystemTimeProvider
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K_R
+import me.uport.sdk.testhelpers.TestTimeProvider
 import org.junit.Test
 
 class CredentialsTest {
@@ -52,6 +53,58 @@ class CredentialsTest {
 
         val (header, _, _) = JWTTools().decode(jwt)
         assert(header.alg).isEqualTo(ES256K)
+
+    }
+
+    @Test
+    fun `create verification test with all params`() = runBlocking {
+
+        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6eyJlZHVjYXRpb24iOiJNYXN0ZXJzIiwicHJvZmVzc2lvbiI6IkludmVzdG1lbnQgQmFua2VyIiwicGFzc29ydCI6IkdFMzQ1OEpDIn0sImNhbGxiYWNrIjoibXlhcHA6Ly9nZXQtYmFjay10by1tZS13aXRoLXJlc3BvbnNlLnVybCIsImlhdCI6MTIzNDU2NzgsImV4cCI6MTIzNDg2NzgsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.nHJXDYJnTj9QBjN90VTqJOzpcldNmeZ_BMTB3ZPeDbwY9Q99iHF1P-yQGRQF7efG-WOQYsdhfpcSle5kEDQ4cg"
+
+        val claim = mapOf("name" to "John Doe",
+                "age" to "35",
+                "location" to "Germany")
+
+        val vc = mapOf("education" to "Masters",
+                "profession" to "Investment Banker",
+                "passort" to "GE3458JC")
+
+        val timeProvider = TestTimeProvider(12345678000L)
+
+        val cred = Credentials("did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX", KPSigner("0x1234"), timeProvider)
+        val jwt = cred.createVerification(
+                "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                claim,
+                "myapp://get-back-to-me-with-response.url",
+                vc,
+                3000L
+        )
+
+        assert(jwt).isEqualTo(expectedJWT)
+
+    }
+
+    @Test
+    fun `create verification test with required params only`() = runBlocking {
+
+        val expectedJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6e30sImNhbGxiYWNrIjoibXlhcHA6Ly9nZXQtYmFjay10by1tZS13aXRoLXJlc3BvbnNlLnVybCIsImlhdCI6MTIzNDU2NzgsImV4cCI6MTIzNDYyNzgsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.Z0rachvLJzskxGJMuV8KwQDbMZE0mrvNbaTMQ5KgwiPFLDlpa7QtvuYQrCqcnLwfPpvWrHwrBLjgQsa8D_g8LA"
+
+        val claim = mapOf("name" to "John Doe",
+                "age" to "35",
+                "location" to "Germany")
+
+        val timeProvider = TestTimeProvider(12345678000L)
+
+        val cred = Credentials("did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX", KPSigner("0x1234"), timeProvider)
+        val jwt = cred.createVerification(
+                "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                claim,
+                "myapp://get-back-to-me-with-response.url",
+                null,
+                null
+        )
+
+        assert(jwt).isEqualTo(expectedJWT)
 
     }
 


### PR DESCRIPTION
#### What's Here
A method to create a specific type of JWT which contains a claim about a subject.

Here is the JS implementation:
https://github.com/uport-project/uport-credentials/blob/0ba1060ab4c99be3de367e55c382f705f7f5d215/src/Credentials.js#L220

#### Testing
Run test suite using `./gradlew test cC --no-parallel`