### PR TITLE
[support] reduce ui test flakiness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
 
     ext {
-
         kotlin_version = '1.3.21'
         kotlin_serialization_version = '0.10.0'
         coroutines_version = "1.1.1"
@@ -27,7 +26,7 @@ buildscript {
         mockito_version = "2.23.0"
         mockito_kotlin_version = "2.0.0"
         robolectric_version = "4.1"
-        mockk_version = "1.9"
+        mockk_version = "1.9.2"
         assertk_version = "0.12"
         detekt_version = "1.0.0-RC14"
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espresso_version"
     androidTestImplementation "com.android.support.test.espresso:espresso-intents:$espresso_version"
     androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espresso_version"
+    androidTestImplementation "com.github.mirceanis:view-matching-idler:0.1"
     androidTestImplementation "io.mockk:mockk-android:$mockk_version"
     androidTestImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
 }

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/CreateAccountTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/CreateAccountTest.kt
@@ -2,25 +2,29 @@ package me.uport.sdk.demoapp
 
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.rule.ActivityTestRule
+import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.hamcrest.core.StringContains.containsString
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class CreateAccountTest {
 
     @get:Rule
     val activityRule = ActivityTestRule(CreateAccountActivity::class.java)
 
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
+
     @Test
     fun accountIsCreated() {
-
-        Thread.sleep(2000)
-
-        onView(withId(R.id.defaultAccountView)).check(matches(withText(not(containsString("ERROR")))))
+        onView(withId(R.id.defaultAccountView))
+                .check(matches(withText(not(containsString("ERROR")))))
     }
 
 }

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/PersonalSignatureTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/PersonalSignatureTest.kt
@@ -11,20 +11,26 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.intent.Intents.intending
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
 import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import me.uport.sdk.demoapp.request_flows.PersonalSignRequestActivity
 import me.uport.sdk.transport.RequestDispatchActivity
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class PersonalSignatureTest {
 
     @get:Rule
     val intentsTestRule = IntentsTestRule(PersonalSignRequestActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     private var instrumentation: Instrumentation? = null
     private var monitor: Instrumentation.ActivityMonitor? = null
@@ -58,8 +64,6 @@ class PersonalSignatureTest {
 
         // User clicks on send request.
         onView(withId(R.id.send_request)).perform(click())
-
-        Thread.sleep(5000)
 
         // Response detail TextView will no longer be empty
         onView(withId(R.id.response_details)).check(matches(not(withText(""))))

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/SelectiveDisclosureFlowTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/SelectiveDisclosureFlowTest.kt
@@ -15,16 +15,21 @@ import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import me.uport.sdk.demoapp.request_flows.uPortLoginActivity
 import me.uport.sdk.transport.RequestDispatchActivity
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 
-class uPortLoginTest {
+class SelectiveDisclosureFlowTest {
 
     @get:Rule
     val intentsTestRule = IntentsTestRule(uPortLoginActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     private var instrumentation: Instrumentation? = null
     private var monitor: Instrumentation.ActivityMonitor? = null
@@ -59,8 +64,6 @@ class uPortLoginTest {
 
         // User starts the uport login activity.
         onView(withId(R.id.btn_send_request)).perform(click())
-
-        Thread.sleep(5000)
 
         // Check if other request flow buttons visible after successful login
         onView(withId(R.id.btn_verified_claim)).check(matches(isDisplayed()))

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/TransactionRequestTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/TransactionRequestTest.kt
@@ -11,20 +11,26 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.intent.Intents.intending
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
 import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import me.uport.sdk.demoapp.request_flows.EthereumTransactionActivity
 import me.uport.sdk.transport.RequestDispatchActivity
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class TransactionRequestTest {
 
     @get:Rule
     val intentsTestRule = IntentsTestRule(EthereumTransactionActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     private var instrumentation: Instrumentation? = null
     private var monitor: Instrumentation.ActivityMonitor? = null
@@ -57,8 +63,6 @@ class TransactionRequestTest {
     fun transaction_request_successfully_approved_by_uport_account() {
         // User clicks on send request.
         onView(withId(R.id.send_request)).perform(click())
-
-        Thread.sleep(5000)
 
         // Response detail TextView will no longer be empty
         onView(withId(R.id.response_details)).check(matches(not(withText(""))))

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/TypedDataTests.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/TypedDataTests.kt
@@ -11,20 +11,26 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.intent.Intents.intending
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
 import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import me.uport.sdk.demoapp.request_flows.TypedDataRequestActivity
 import me.uport.sdk.transport.RequestDispatchActivity
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class TypedDataTests {
 
     @get:Rule
     val intentsTestRule = IntentsTestRule(TypedDataRequestActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     private var instrumentation: Instrumentation? = null
     private var monitor: Instrumentation.ActivityMonitor? = null
@@ -58,8 +64,6 @@ class TypedDataTests {
 
         // User clicks on send request.
         onView(withId(R.id.send_request)).perform(click())
-
-        Thread.sleep(5000)
 
         // Response detail TextView will no longer be empty
         onView(withId(R.id.response_details)).check(matches(not(withText(""))))

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/VerifiedClaimTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/VerifiedClaimTest.kt
@@ -11,20 +11,26 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.intent.Intents.intending
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
 import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import me.uport.sdk.demoapp.request_flows.VerifiedClaimRequestActivity
 import me.uport.sdk.transport.RequestDispatchActivity
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class VerifiedClaimTest {
 
     @get:Rule
     val intentsTestRule = IntentsTestRule(VerifiedClaimRequestActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     private var instrumentation: Instrumentation? = null
     private var monitor: Instrumentation.ActivityMonitor? = null
@@ -58,8 +64,6 @@ class VerifiedClaimTest {
 
         // User clicks on send request.
         onView(withId(R.id.send_request)).perform(click())
-
-        Thread.sleep(5000)
 
         // Response detail textview will no longer be empty
         onView(withId(R.id.response_details)).check(matches(not(withText(""))))

--- a/demoapp/src/androidTest/java/me/uport/sdk/demoapp/VerifyJWTTest.kt
+++ b/demoapp/src/androidTest/java/me/uport/sdk/demoapp/VerifyJWTTest.kt
@@ -3,6 +3,7 @@ package me.uport.sdk.demoapp
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.rule.ActivityTestRule
@@ -15,13 +16,18 @@ import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.universaldid.UniversalDID
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers.allOf
 import org.junit.Rule
 import org.junit.Test
+import ro.mirceanistor.testutil.ViewMatcherIdlingRule
 
 class VerifyJWTTest {
 
     @get:Rule
     val activityRule = ActivityTestRule(VerifyJWTActivity::class.java)
+
+    @get:Rule
+    val viewMatcherIdlingRule = ViewMatcherIdlingRule(allOf(withId(R.id.progress), isDisplayed()))
 
     @Test
     fun can_verify_jwt_in_activity() {
@@ -60,8 +66,6 @@ class VerifyJWTTest {
         UniversalDID.registerResolver(ethrResolver)
 
         onView(withId(R.id.verify_btn)).perform(click())
-        //XXX: for some reason the animated progressbar is not getting registered in espresso
-        Thread.sleep(2000)
 
         onView(withId(R.id.jwtPayload)).check(matches(not(withText(""))))
     }


### PR DESCRIPTION
### What's here

This PR eliminates most of the `Thread.sleep()` calls from UI tests by deferring to an `Espresso` `IdlingResource` tied to the visibility of the progress bar.

There's also a bump in the version of `mockk` that clears an annoying warning.

### Testing

Run `./gradlew :demoapp:cC --no-parallel` with device(s) and/or emulator(s) connected.