### PR TITLE
Feature/163365374 verify parse response

### DIFF
--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -6,6 +6,8 @@ import com.uport.sdk.signer.Signer
 import me.uport.mnid.MNID
 import me.uport.sdk.core.ITimeProvider
 import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.jwt.InvalidJWTException
+import me.uport.sdk.jwt.JWTEncodingException
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.JWTTools.Companion.DEFAULT_JWT_VALIDITY_SECONDS
 import me.uport.sdk.jwt.model.JwtHeader
@@ -166,7 +168,10 @@ class Credentials(
         payload.verified?.forEach {
             try {
                 valid.add(JWTTools().verify(it))
-            } catch (e: Exception) {
+            } catch (e: InvalidJWTException) {
+                e.printStackTrace()
+                invalid.add(it)
+            } catch (e: JWTEncodingException) {
                 e.printStackTrace()
                 invalid.add(it)
             }
@@ -176,7 +181,9 @@ class Credentials(
                 payload.iss,
                 payload.net,
                 valid,
-                invalid
+                invalid,
+                payload.own?.get("email"),
+                payload.own?.get("name")
         )
     }
 

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -6,8 +6,6 @@ import com.uport.sdk.signer.Signer
 import me.uport.mnid.MNID
 import me.uport.sdk.core.ITimeProvider
 import me.uport.sdk.core.SystemTimeProvider
-import me.uport.sdk.jwt.InvalidJWTException
-import me.uport.sdk.jwt.JWTEncodingException
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.JWTTools.Companion.DEFAULT_JWT_VALIDITY_SECONDS
 import me.uport.sdk.jwt.model.JwtHeader
@@ -154,11 +152,12 @@ class Credentials(
      * Verify and return profile from a
      * [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
      *
-     * @param payload **REQUIRED** The JWT response token from a selective disclosure request
+     * @param token **REQUIRED** The JWT response token from a selective disclosure request
      *
      * @return a [UportProfile] object
      */
-    suspend fun verifyDisclosure(token: String): UportProfile? {
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun verifyDisclosure(token: String): UportProfile {
 
         val (_, payload, _) = JWTTools().decode(token)
 
@@ -168,10 +167,7 @@ class Credentials(
         payload.verified?.forEach {
             try {
                 valid.add(JWTTools().verify(it))
-            } catch (e: InvalidJWTException) {
-                e.printStackTrace()
-                invalid.add(it)
-            } catch (e: JWTEncodingException) {
+            } catch (e: Exception) {
                 e.printStackTrace()
                 invalid.add(it)
             }

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -128,7 +128,7 @@ class Credentials(
      * @param callbackUrl **OPTIONAL** the URL that receives the response
      * @param expiresInSeconds **OPTIONAL** number of seconds of validity of the claim.
      * @param verifiedClaims **OPTIONAL** a list of verified claims which can be about anything
- *                          related to the claim and in most cases it is related to the issuer
+     *                          related to the claim and in most cases it is related to the issuer
      *
      *  ```
      */
@@ -144,6 +144,20 @@ class Credentials(
         payload["vc"] = verifiedClaims ?: emptyList<String>()
         payload["callback"] = callbackUrl ?: ""
         return this.signJWT(payload, expiresInSeconds ?: 600L)
+    }
+
+
+    /**
+     * Verify and return profile from a
+     * [Selective Disclosure Response JWT](https://github.com/uport-project/specs/blob/develop/messages/shareresp.md).
+     *
+     * @param token **REQUIRED** The JWT response token from a selective disclosure request
+     *
+     * @return a [UportProfile] object
+     */
+    fun verifyDisclosure(token: String): UportProfile? {
+        //TODO: weak, make Configuration into a builder and actually make methods fail when not configured
+        return null
     }
 
 

--- a/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
@@ -2,6 +2,10 @@ package me.uport.sdk.credentials
 
 import me.uport.sdk.jwt.model.JwtPayload
 
+
+/**
+ * This class is used to create a uPort profile
+ */
 data class UportProfile(
 
         /**

--- a/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
@@ -50,5 +50,5 @@ data class UportProfile(
          * This can hold extra fields for the uPort profile.
          * Use this to provide any extra fields that are not covered by the current version of the SDK
          */
-        val extras: Map<String, Any>? = null
+        val extras: Map<String, Any?>? = null
 )

--- a/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
@@ -2,11 +2,49 @@ package me.uport.sdk.credentials
 
 import me.uport.sdk.jwt.model.JwtPayload
 
-data class UportProfile(val did: String,
-                        val network: String,
-                        val boxPub: String,
-                        val name: String?,
-                        val email: String?,
-                        val extras: Map<String, Any>,
-                        val invalid: List<String>,
-                        val valid: List<JwtPayload>)
+data class UportProfile(
+
+        /**
+         * DID associated with the uPort profile
+         */
+        val did: String,
+
+
+        /**
+         * network id of Ethereum chain of identity
+         * eg. 0x4 for rinkeby. It defaults to 0x1 for mainnet.
+         */
+        val networkId: String?,
+
+
+        /**
+         * A list of verified JWT payloads associated with this uPort profile
+         */
+        val valid: Collection<JwtPayload>,
+
+
+        /**
+         * A list of invalid JWT tokens associated with this uPort profile
+         */
+        val invalid: Collection<String>,
+
+
+        /**
+         * The email on the uPort profile
+         */
+        val email: String? = null,
+
+
+        /**
+         * The name on the uPort profile
+         */
+        val name: String? = null,
+
+
+        /**
+         * [**optional**]
+         * This can hold extra fields for the uPort profile.
+         * Use this to provide any extra fields that are not covered by the current version of the SDK
+         */
+        val extras: Map<String, Any>? = null
+)

--- a/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/UportProfile.kt
@@ -1,0 +1,12 @@
+package me.uport.sdk.credentials
+
+import me.uport.sdk.jwt.model.JwtPayload
+
+data class UportProfile(val did: String,
+                        val network: String,
+                        val boxPub: String,
+                        val name: String?,
+                        val email: String?,
+                        val extras: Map<String, Any>,
+                        val invalid: List<String>,
+                        val valid: List<JwtPayload>)

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -231,19 +231,17 @@ class CredentialsTest {
                 "iat" to 1556541978,
                 "exp" to 1556628378,
                 "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                "callback" to "https://chasqui.uport.me/api/v1/topic/XnHfyev51xsdkDtu",
-                "type" to "shareReq",
                 "net" to "0x4",
                 "own" to mapOf(
                         "name" to "Mike Gunn",
                         "email" to "mgunn@uport.me"
                 ),
-                "requested" to listOf("name", "phone", "country", "avatar"),
                 "verified" to listOf(
                         "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTU1NjcwMTA3NCwiZXhwIjoxNzIwMzY2NDMyLCJuZXQiOiIweDQiLCJ0eXBlIjoic2hhcmVSZXEifQ.PjsCopgtHxfTkGrQUT1ID7P8bfXyeCZoy0GnHw5p8xv6mJYDE9MAVQK6sjEivXyOQhb2bWs4Pm9vWl4dFEhpGwE",
                         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU"
                 ),
-                "permissions" to listOf("notifications")
+                "permissions" to listOf("notifications"),
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiXSwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NjcyMTQxMywiZXhwIjoxNTU2NzIyMDEzLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.KfDgkaOWZxxfprgBxPvC2wSd-BrhdjN-gTf7br5Li4LtTgSmk9I55dE2xWekSSWTaQxC74DDRCxrEsVH3I1bWwE"
         )
 
         val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))
@@ -263,12 +261,11 @@ class CredentialsTest {
 
         val map = mapOf<String, Any>(
                 "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                "type" to "shareReq",
                 "own" to mapOf(
                         "name" to "Mike Gunn"
                 ),
-                "requested" to listOf("name", "phone", "country", "avatar"),
-                "permissions" to listOf("notifications")
+                "permissions" to listOf("notifications"),
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiXSwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NjcyMTQxMywiZXhwIjoxNTU2NzIyMDEzLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.KfDgkaOWZxxfprgBxPvC2wSd-BrhdjN-gTf7br5Li4LtTgSmk9I55dE2xWekSSWTaQxC74DDRCxrEsVH3I1bWwE"
         )
 
         val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -6,14 +6,11 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isNotNull
 import com.uport.sdk.signer.KPSigner
-import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import me.uport.sdk.core.SystemTimeProvider
 import me.uport.sdk.jwt.JWTTools
-import me.uport.sdk.jwt.model.JwtHeader
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K_R
-import me.uport.sdk.jwt.model.JwtPayload
 import me.uport.sdk.testhelpers.TestTimeProvider
 import org.junit.Test
 
@@ -229,11 +226,9 @@ class CredentialsTest {
     @Test
     fun `can return uport profile from jwt payload`() = runBlocking {
 
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ"
+        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJoZWxsbyIsImlhdCI6MTU1NjU0MTk3OCwiZXhwIjoxNTU2NjI4Mzc4LCJhdWQiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQiLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsInR5cGUiOiJzaGFyZVJlc3AiLCJqdGkiOiJhOGNmYWE0YS1mOGUxLTQ3YmEtOTE2ZS1lZDFhNjUyN2Y1ZTUiLCJ2ZXJpZmllZCI6WyJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUprYVdRNlpYUm9jam93ZUdZelltVmhZek13WXpRNU9HUTVaVEkyT0RZMVpqTTBabU5oWVRVM1pHSmlPVE0xWWpCa056UWlMQ0psWkhWallYUnBiMjRpT2lKTllYTjBaWEp6SWl3aWFXRjBJam94TlRFMk1qTTVNREl5ZlEud1RuUGhnTWJyU2xyV2NmUjdfX3hXYmxHLUEzbmdqTFQyYlBfTTdaOW1pWSIsImV5SmhiR2NpT2lKSVV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUp6ZFdJaU9pSmthV1E2WlhSb2Nqb3dlR1l6WW1WaFl6TXdZelE1T0dRNVpUSTJPRFkxWmpNMFptTmhZVFUzWkdKaU9UTTFZakJrTnpRaUxDSnNiMk5oZEdsdmJpSTZJbFJsZUdGeklpd2lhV0YwSWpveE5URTJNak01TURJeWZRLk8yb3FZNHBnbUFtV3FlT3Q3NlBUaUIzeTlqRUdmMlphWEVoSVJlTTlJTFUiLCJleUpwYzNNaU9pSXliMlZZZFdaSVIwUndWVFV4WW1aTFFuTmFSR1IxTjBwbE9YZGxTak55TjNOV1J5SXNJbWxoZENJNk1UVXlNRE0yTmpRek1pd2ljbVZ4ZFdWemRHVmtJanBiSW01aGJXVWlMQ0p3YUc5dVpTSXNJbU52ZFc1MGNua2lMQ0poZG1GMFlYSWlYU3dpY0dWeWJXbHpjMmx2Ym5NaU9sc2libTkwYVdacFkyRjBhVzl1Y3lKZExDSmpZV3hzWW1GamF5STZJbWgwZEhCek9pOHZZMmhoYzNGMWFTNTFjRzl5ZEM1dFpTOWhjR2t2ZGpFdmRHOXdhV012V0c1SVpubGxkalV4ZUhOa2EwUjBkU0lzSW01bGRDSTZJakI0TkNJc0ltVjRjQ0k2TVRVeU1ETTJOekF6TWl3aWRIbHdaU0k2SW5Ob1lYSmxVbVZ4SW4wLkM4bVBDQ3RXbFlBbnJvZHVxeXNYWVJsNXh2ck9keDFyNGlxM0EzU21HREdadTQ3VUdUbmppWkNPck9ROEE1bFowTTlKZkRwWkRFVENLR2RKN0tVZVdRIl0sIm5ldCI6IjB4NCIsIm93biI6eyJuYW1lIjoiTWlrZSBHdW5uIiwiZW1haWwiOiJtZ3VubkB1cG9ydC5tZSJ9fQ.075oRsNEJg-BrZIWuBd2p_r1EWxVM0pqT3s6TeaFvRo"
 
-        val tested = JWTTools()
-
-        val payload = JwtPayload(
+        /*val payload = JwtPayload(
                 iss = "did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431",
                 iat = 1556541978,
                 sub = null,
@@ -266,21 +261,20 @@ class CredentialsTest {
                 rel = null,
                 fct = null,
                 acc = null
-        )
+        )*/
 
-        coEvery {
-            tested.decode(token)
+        /*coEvery {
+            tested.decode(eq("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6W10sImNhbGxiYWNrIjoiIiwiaWF0IjoxMjM0NTY3OCwiZXhwIjoxMjM0NjI3OCwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.C5sY_WCnSjYmqX-w3NZo9AmB6qVUy-Uwd6Fzz24CtbK0JWAYxgslqr6-JYjkB5O5Eu9IJYNS-1pKH-waNGGwmA"))
         }.returns(
                 Triple(JwtHeader(alg = "ES256K-R"), payload, byteArrayOf(0, 1, 2, 3, 4))
-        )
+        )*/
 
         val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
 
         assert(uPortProfile).isNotNull()
-        assert(uPortProfile?.did).isEqualTo(payload.iss)
-        assert(uPortProfile?.networkId).isEqualTo(payload.net)
+        assert(uPortProfile?.did).isEqualTo("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431")
+        assert(uPortProfile?.networkId).isEqualTo("0x4")
         assert(uPortProfile?.name).isEqualTo("Mike Gunn")
         assert(uPortProfile?.email).isEqualTo("mgunn@uport.me")
     }
-
 }

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -6,12 +6,18 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isNotNull
 import com.uport.sdk.signer.KPSigner
+import io.mockk.coEvery
+import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.ethrdid.EthrDIDDocument
+import me.uport.sdk.ethrdid.EthrDIDResolver
+import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K_R
 import me.uport.sdk.testhelpers.TestTimeProvider
+import me.uport.sdk.universaldid.UniversalDID
 import org.junit.Test
 
 class CredentialsTest {
@@ -229,7 +235,7 @@ class CredentialsTest {
 
         val map = mapOf<String, Any>(
                 "iat" to 1556541978,
-                "exp" to 1556628378,
+                "exp" to 1656628378,
                 "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
                 "net" to "0x4",
                 "own" to mapOf(
@@ -238,18 +244,40 @@ class CredentialsTest {
                 ),
                 "verified" to listOf(
                         "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTU1NjcwMTA3NCwiZXhwIjoxNzIwMzY2NDMyLCJuZXQiOiIweDQiLCJ0eXBlIjoic2hhcmVSZXEifQ.PjsCopgtHxfTkGrQUT1ID7P8bfXyeCZoy0GnHw5p8xv6mJYDE9MAVQK6sjEivXyOQhb2bWs4Pm9vWl4dFEhpGwE",
-                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU"
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjbGFpbXMiOnsibmFtZSI6IlIgRGFuZWVsIE9saXZhdyJ9LCJpYXQiOjEyMzQ1Njc4LCJleHAiOjEyMzQ1OTc4LCJpc3MiOiJkaWQ6ZXRocjoweDQxMjNjYmQxNDNiNTVjMDZlNDUxZmYyNTNhZjA5Mjg2YjY4N2E5NTAifQ.o6eDKYjHJnak1ylkpe9g8krxvK9UEhKf-1T0EYhH8pGyb8MjOEepRJi8DYlVEnZno0DkVYXQCf3u1i_HThBKtAA"
                 ),
                 "permissions" to listOf("notifications"),
                 "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiXSwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NjcyMTQxMywiZXhwIjoxNTU2NzIyMDEzLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.KfDgkaOWZxxfprgBxPvC2wSd-BrhdjN-gTf7br5Li4LtTgSmk9I55dE2xWekSSWTaQxC74DDRCxrEsVH3I1bWwE"
         )
 
-        val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
 
-        val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        val uPortProfile = Credentials(issuer, signer).verifyDisclosure(token)
 
         assert(uPortProfile).isNotNull()
-        assert(uPortProfile.did).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
+        assert(uPortProfile.did).isEqualTo(issuer)
         assert(uPortProfile.networkId).isEqualTo("0x4")
         assert(uPortProfile.name).isEqualTo("Mike Gunn")
         assert(uPortProfile.email).isEqualTo("mgunn@uport.me")
@@ -257,24 +285,90 @@ class CredentialsTest {
     }
 
     @Test
-    fun `can return uport profile from jwt payload without all params`() = runBlocking {
+    @Suppress("UNCHECKED_CAST")
+    fun `can fetch networkId from request token`() = runBlocking {
 
         val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1656628378,
                 "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
                 "own" to mapOf(
-                        "name" to "Mike Gunn"
+                        "name" to "Mike Gunn",
+                        "email" to "mgunn@uport.me"
                 ),
+                "permissions" to listOf("notifications"),
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiLCJib3hQdWIiLCJuZXQiXSwibmV0IjoiMHg0IiwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NzEzNzczMCwiZXhwIjoxNTU3MTM4MzMwLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.xPnTKcFsE3MRxkm6I__xSRVSFQgIT5tUgfL_O7q0hfPTNxnA8DM53yqMdl_1stqzoIv2VKgMC40oFfYh9Ql-TAA"
+        )
+
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
+
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        val uPortProfile = Credentials(issuer, signer).verifyDisclosure(token)
+
+        assert(uPortProfile).isNotNull()
+        assert(uPortProfile.networkId).isEqualTo("0x4")
+    }
+
+    @Test
+    fun `can return uport profile from jwt payload without all properties`() = runBlocking {
+
+        val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1656628378,
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
                 "permissions" to listOf("notifications"),
                 "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiXSwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NjcyMTQxMywiZXhwIjoxNTU2NzIyMDEzLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.KfDgkaOWZxxfprgBxPvC2wSd-BrhdjN-gTf7br5Li4LtTgSmk9I55dE2xWekSSWTaQxC74DDRCxrEsVH3I1bWwE"
         )
 
-        val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
 
-        val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        val uPortProfile = Credentials(issuer, signer).verifyDisclosure(token)
 
         assert(uPortProfile).isNotNull()
-        assert(uPortProfile.did).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
-        assert(uPortProfile.name).isEqualTo("Mike Gunn")
+        assert(uPortProfile.did).isEqualTo(issuer)
     }
 
 }

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -6,11 +6,14 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isNotNull
 import com.uport.sdk.signer.KPSigner
+import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import me.uport.sdk.core.SystemTimeProvider
 import me.uport.sdk.jwt.JWTTools
+import me.uport.sdk.jwt.model.JwtHeader
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K_R
+import me.uport.sdk.jwt.model.JwtPayload
 import me.uport.sdk.testhelpers.TestTimeProvider
 import org.junit.Test
 
@@ -221,6 +224,63 @@ class CredentialsTest {
         assert(load["sub"]).isEqualTo("did:ethr:0xFFEEDDCCBBAA9988776655443322110099887766")
         assert(load["issc"]).isEqualTo(mapOf("dappName" to "testing"))
         assert(load["rexp"]).isEqualTo(1234L)
+    }
+
+    @Test
+    fun `can return uport profile from jwt payload`() = runBlocking {
+
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ"
+
+        val tested = JWTTools()
+
+        val payload = JwtPayload(
+                iss = "did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431",
+                iat = 1556541978,
+                sub = null,
+                aud = "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                exp = 1556628378,
+                callback = "https://chasqui.uport.me/api/v1/topic/XnHfyev51xsdkDtu",
+                type = "shareReq",
+                net = "0x4",
+                act = null,
+                requested = listOf("name", "phone", "country", "avatar"),
+                verified = listOf(
+                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJlZHVjYXRpb24iOiJNYXN0ZXJzIiwiaWF0IjoxNTE2MjM5MDIyfQ.wTnPhgMbrSlrWcfR7__xWblG-A3ngjLT2bP_M7Z9miY",
+                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU",
+                        "eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ",
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ",
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
+                ),
+                permissions = listOf("notifications"),
+                req = null,
+                nad = null,
+                dad = null,
+                own = mapOf(
+                        "name" to "Mike Gunn",
+                        "email" to "mgunn@uport.me"
+                ),
+                capabilities = null,
+                claims = null,
+                ctl = null,
+                reg = null,
+                rel = null,
+                fct = null,
+                acc = null
+        )
+
+        coEvery {
+            tested.decode(token)
+        }.returns(
+                Triple(JwtHeader(alg = "ES256K-R"), payload, byteArrayOf(0, 1, 2, 3, 4))
+        )
+
+        val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
+
+        assert(uPortProfile).isNotNull()
+        assert(uPortProfile?.did).isEqualTo(payload.iss)
+        assert(uPortProfile?.networkId).isEqualTo(payload.net)
+        assert(uPortProfile?.name).isEqualTo("Mike Gunn")
+        assert(uPortProfile?.email).isEqualTo("mgunn@uport.me")
     }
 
 }

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -224,57 +224,60 @@ class CredentialsTest {
     }
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun `can return uport profile from jwt payload`() = runBlocking {
 
-        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJoZWxsbyIsImlhdCI6MTU1NjU0MTk3OCwiZXhwIjoxNTU2NjI4Mzc4LCJhdWQiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQiLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsInR5cGUiOiJzaGFyZVJlc3AiLCJqdGkiOiJhOGNmYWE0YS1mOGUxLTQ3YmEtOTE2ZS1lZDFhNjUyN2Y1ZTUiLCJ2ZXJpZmllZCI6WyJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUprYVdRNlpYUm9jam93ZUdZelltVmhZek13WXpRNU9HUTVaVEkyT0RZMVpqTTBabU5oWVRVM1pHSmlPVE0xWWpCa056UWlMQ0psWkhWallYUnBiMjRpT2lKTllYTjBaWEp6SWl3aWFXRjBJam94TlRFMk1qTTVNREl5ZlEud1RuUGhnTWJyU2xyV2NmUjdfX3hXYmxHLUEzbmdqTFQyYlBfTTdaOW1pWSIsImV5SmhiR2NpT2lKSVV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUp6ZFdJaU9pSmthV1E2WlhSb2Nqb3dlR1l6WW1WaFl6TXdZelE1T0dRNVpUSTJPRFkxWmpNMFptTmhZVFUzWkdKaU9UTTFZakJrTnpRaUxDSnNiMk5oZEdsdmJpSTZJbFJsZUdGeklpd2lhV0YwSWpveE5URTJNak01TURJeWZRLk8yb3FZNHBnbUFtV3FlT3Q3NlBUaUIzeTlqRUdmMlphWEVoSVJlTTlJTFUiLCJleUpwYzNNaU9pSXliMlZZZFdaSVIwUndWVFV4WW1aTFFuTmFSR1IxTjBwbE9YZGxTak55TjNOV1J5SXNJbWxoZENJNk1UVXlNRE0yTmpRek1pd2ljbVZ4ZFdWemRHVmtJanBiSW01aGJXVWlMQ0p3YUc5dVpTSXNJbU52ZFc1MGNua2lMQ0poZG1GMFlYSWlYU3dpY0dWeWJXbHpjMmx2Ym5NaU9sc2libTkwYVdacFkyRjBhVzl1Y3lKZExDSmpZV3hzWW1GamF5STZJbWgwZEhCek9pOHZZMmhoYzNGMWFTNTFjRzl5ZEM1dFpTOWhjR2t2ZGpFdmRHOXdhV012V0c1SVpubGxkalV4ZUhOa2EwUjBkU0lzSW01bGRDSTZJakI0TkNJc0ltVjRjQ0k2TVRVeU1ETTJOekF6TWl3aWRIbHdaU0k2SW5Ob1lYSmxVbVZ4SW4wLkM4bVBDQ3RXbFlBbnJvZHVxeXNYWVJsNXh2ck9keDFyNGlxM0EzU21HREdadTQ3VUdUbmppWkNPck9ROEE1bFowTTlKZkRwWkRFVENLR2RKN0tVZVdRIl0sIm5ldCI6IjB4NCIsIm93biI6eyJuYW1lIjoiTWlrZSBHdW5uIiwiZW1haWwiOiJtZ3VubkB1cG9ydC5tZSJ9fQ.075oRsNEJg-BrZIWuBd2p_r1EWxVM0pqT3s6TeaFvRo"
-
-        /*val payload = JwtPayload(
-                iss = "did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431",
-                iat = 1556541978,
-                sub = null,
-                aud = "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                exp = 1556628378,
-                callback = "https://chasqui.uport.me/api/v1/topic/XnHfyev51xsdkDtu",
-                type = "shareReq",
-                net = "0x4",
-                act = null,
-                requested = listOf("name", "phone", "country", "avatar"),
-                verified = listOf(
-                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJlZHVjYXRpb24iOiJNYXN0ZXJzIiwiaWF0IjoxNTE2MjM5MDIyfQ.wTnPhgMbrSlrWcfR7__xWblG-A3ngjLT2bP_M7Z9miY",
-                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU",
-                        "eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ",
-                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTUyMDM2NjQzMiwicmVxdWVzdGVkIjpbIm5hbWUiLCJwaG9uZSIsImNvdW50cnkiLCJhdmF0YXIiXSwicGVybWlzc2lvbnMiOlsibm90aWZpY2F0aW9ucyJdLCJjYWxsYmFjayI6Imh0dHBzOi8vY2hhc3F1aS51cG9ydC5tZS9hcGkvdjEvdG9waWMvWG5IZnlldjUxeHNka0R0dSIsIm5ldCI6IjB4NCIsImV4cCI6MTUyMDM2NzAzMiwidHlwZSI6InNoYXJlUmVxIn0.C8mPCCtWlYAnroduqysXYRl5xvrOdx1r4iq3A3SmGDGZu47UGTnjiZCOrOQ8A5lZ0M9JfDpZDETCKGdJ7KUeWQ",
-                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
-                ),
-                permissions = listOf("notifications"),
-                req = null,
-                nad = null,
-                dad = null,
-                own = mapOf(
+        val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1556628378,
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                "callback" to "https://chasqui.uport.me/api/v1/topic/XnHfyev51xsdkDtu",
+                "type" to "shareReq",
+                "net" to "0x4",
+                "own" to mapOf(
                         "name" to "Mike Gunn",
                         "email" to "mgunn@uport.me"
                 ),
-                capabilities = null,
-                claims = null,
-                ctl = null,
-                reg = null,
-                rel = null,
-                fct = null,
-                acc = null
-        )*/
+                "requested" to listOf("name", "phone", "country", "avatar"),
+                "verified" to listOf(
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpc3MiOiIyb2VYdWZIR0RwVTUxYmZLQnNaRGR1N0plOXdlSjNyN3NWRyIsImlhdCI6MTU1NjcwMTA3NCwiZXhwIjoxNzIwMzY2NDMyLCJuZXQiOiIweDQiLCJ0eXBlIjoic2hhcmVSZXEifQ.PjsCopgtHxfTkGrQUT1ID7P8bfXyeCZoy0GnHw5p8xv6mJYDE9MAVQK6sjEivXyOQhb2bWs4Pm9vWl4dFEhpGwE",
+                        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJsb2NhdGlvbiI6IlRleGFzIiwiaWF0IjoxNTE2MjM5MDIyfQ.O2oqY4pgmAmWqeOt76PTiB3y9jEGf2ZaXEhIReM9ILU"
+                ),
+                "permissions" to listOf("notifications")
+        )
 
-        /*coEvery {
-            tested.decode(eq("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJzdWIiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJjbGFpbSI6eyJuYW1lIjoiSm9obiBEb2UiLCJhZ2UiOiIzNSIsImxvY2F0aW9uIjoiR2VybWFueSJ9LCJ2YyI6W10sImNhbGxiYWNrIjoiIiwiaWF0IjoxMjM0NTY3OCwiZXhwIjoxMjM0NjI3OCwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.C5sY_WCnSjYmqX-w3NZo9AmB6qVUy-Uwd6Fzz24CtbK0JWAYxgslqr6-JYjkB5O5Eu9IJYNS-1pKH-waNGGwmA"))
-        }.returns(
-                Triple(JwtHeader(alg = "ES256K-R"), payload, byteArrayOf(0, 1, 2, 3, 4))
-        )*/
+        val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))
 
         val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
 
         assert(uPortProfile).isNotNull()
-        assert(uPortProfile?.did).isEqualTo("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431")
-        assert(uPortProfile?.networkId).isEqualTo("0x4")
-        assert(uPortProfile?.name).isEqualTo("Mike Gunn")
-        assert(uPortProfile?.email).isEqualTo("mgunn@uport.me")
+        assert(uPortProfile.did).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
+        assert(uPortProfile.networkId).isEqualTo("0x4")
+        assert(uPortProfile.name).isEqualTo("Mike Gunn")
+        assert(uPortProfile.email).isEqualTo("mgunn@uport.me")
+        assert(uPortProfile.invalid.size + uPortProfile.valid.size).isEqualTo((map.get("verified") as List<String>?)?.size)
     }
+
+    @Test
+    fun `can return uport profile from jwt payload without all params`() = runBlocking {
+
+        val map = mapOf<String, Any>(
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                "type" to "shareReq",
+                "own" to mapOf(
+                        "name" to "Mike Gunn"
+                ),
+                "requested" to listOf("name", "phone", "country", "avatar"),
+                "permissions" to listOf("notifications")
+        )
+
+        val token = JWTTools().createJWT(map, "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", KPSigner("0x123"))
+
+        val uPortProfile = Credentials("did:ethr:0x3ff25117c0e170ca530bd5891899c183944db431", KPSigner("0x1234")).verifyDisclosure(token)
+
+        assert(uPortProfile).isNotNull()
+        assert(uPortProfile.did).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
+        assert(uPortProfile.name).isEqualTo("Mike Gunn")
+    }
+
 }

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -2,19 +2,8 @@ package me.uport.sdk.jwt
 
 import android.content.Context
 import com.squareup.moshi.JsonAdapter
-import com.uport.sdk.signer.Signer
-import com.uport.sdk.signer.UportHDSigner
-import com.uport.sdk.signer.decodeJose
-import com.uport.sdk.signer.getJoseEncoded
-import com.uport.sdk.signer.normalize
-import me.uport.sdk.core.EthNetwork
-import me.uport.sdk.core.ITimeProvider
-import me.uport.sdk.core.Networks
-import me.uport.sdk.core.SystemTimeProvider
-import me.uport.sdk.core.decodeBase64
-import me.uport.sdk.core.toBase64
-import me.uport.sdk.core.toBase64UrlSafe
-import me.uport.sdk.core.utf8
+import com.uport.sdk.signer.*
+import me.uport.sdk.core.*
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.httpsdid.HttpsDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
@@ -257,7 +246,6 @@ class JWTTools(
         } else {
             throw InvalidJWTException("Signature invalid for JWT. DID document for ${payload.iss} does not have any matching public keys")
         }
-
     }
 
     /**


### PR DESCRIPTION
#### What's Here
This PR adds a method to parse the payload in response from a Selective Disclosure Request and returns a `UportProfile`. This replicates the implementation  from the JS credentials library https://github.com/uport-project/uport-credentials/blob/0b5a62777127131f0dd862576798a910875080e0/src/Credentials.js#L512

#### Testing
Run gradle command `./gradlew test cC --no-parallel`