### PR TITLE
Authenticating a Selective Disclosure Response

### DIFF
--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -161,7 +161,7 @@ class Credentials(
      *
      */
     suspend fun authenticateDisclosure(token: String): JwtPayload {
-        val payload = JWTTools().verify(token)
+        val payload = JWTTools().verify(token, true)
 
         if (payload.req == null) {
             throw JWTAuthenticationException("Challenge was not included in response")
@@ -169,8 +169,8 @@ class Credentials(
 
         val challenge = JWTTools().verify(payload.req ?: "")
 
-        if (challenge.iss != payload.iss) {
-            throw JWTAuthenticationException("Challenge issuer does not match current identity: ${challenge.iss} != ${payload.iss}")
+        if (challenge.iss != this.did) {
+            throw JWTAuthenticationException("Challenge issuer does not match current identity: ${challenge.iss} != ${this.did}")
         }
 
         if (challenge.type != JWTTypes.shareReq.name) {

--- a/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/Credentials.kt
@@ -6,7 +6,7 @@ import com.uport.sdk.signer.Signer
 import me.uport.mnid.MNID
 import me.uport.sdk.core.ITimeProvider
 import me.uport.sdk.core.SystemTimeProvider
-import me.uport.sdk.jwt.InvalidJWTException
+import me.uport.sdk.jwt.JWTAuthenticationException
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.JWTTools.Companion.DEFAULT_JWT_VALIDITY_SECONDS
 import me.uport.sdk.jwt.model.JwtHeader
@@ -157,24 +157,24 @@ class Credentials(
      *
      * @param token **REQUIRED** a valid JWT response token
      * @returns  a verified [JWTPayload]
-     * @throws [InvalidJWTException] when the challenge is failed or when the request token is unavailable
+     * @throws [JWTAuthenticationException] when the challenge is failed or when the request token is unavailable
      *
      */
     suspend fun authenticateDisclosure(token: String): JwtPayload {
         val payload = JWTTools().verify(token)
 
         if (payload.req == null) {
-            throw InvalidJWTException("Challenge was not included in response")
+            throw JWTAuthenticationException("Challenge was not included in response")
         }
 
         val challenge = JWTTools().verify(payload.req ?: "")
 
         if (challenge.iss != payload.iss) {
-            throw InvalidJWTException("Challenge issuer does not match current identity: ${challenge.iss} != ${payload.iss}")
+            throw JWTAuthenticationException("Challenge issuer does not match current identity: ${challenge.iss} != ${payload.iss}")
         }
 
         if (challenge.type != JWTTypes.shareReq.name) {
-            throw InvalidJWTException("Challenge payload type invalid: ${challenge.type}")
+            throw JWTAuthenticationException("Challenge payload type invalid: ${challenge.type}")
         }
 
         return payload

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -1,17 +1,22 @@
 package me.uport.sdk.credentials
 
 import assertk.assert
-import assertk.assertions.isEmpty
-import assertk.assertions.isEqualTo
-import assertk.assertions.isGreaterThanOrEqualTo
-import assertk.assertions.isNotNull
+import assertk.assertions.*
 import com.uport.sdk.signer.KPSigner
+import io.mockk.coEvery
+import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.ethrdid.EthrDIDDocument
+import me.uport.sdk.ethrdid.EthrDIDResolver
+import me.uport.sdk.jsonrpc.JsonRPC
+import me.uport.sdk.jwt.JWTAuthenticationException
 import me.uport.sdk.jwt.JWTTools
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K
 import me.uport.sdk.jwt.model.JwtHeader.Companion.ES256K_R
 import me.uport.sdk.testhelpers.TestTimeProvider
+import me.uport.sdk.testhelpers.coAssert
+import me.uport.sdk.universaldid.UniversalDID
 import org.junit.Test
 
 class CredentialsTest {
@@ -223,4 +228,143 @@ class CredentialsTest {
         assert(load["rexp"]).isEqualTo(1234L)
     }
 
+
+    @Test
+    fun `successfully authenticates selective disclosure response`() = runBlocking {
+
+        val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1656628378,
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                "net" to "0x4",
+                "own" to mapOf(
+                        "name" to "Mike Gunn",
+                        "email" to "mgunn@uport.me"
+                ),
+                "permissions" to listOf("notifications"),
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwicmVxdWVzdGVkIjpbIm5hbWUiXSwiYWN0IjoiZ2VuZXJhbCIsInR5cGUiOiJzaGFyZVJlcSIsImlhdCI6MTU1NzM5NTExOCwiZXhwIjo5MDAwMDAwMDAxNTU3Mzk1MTE4LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.6UVkmO5vXyNtn6gy_RKz1Wjx1eWqik_124aBfcmKFr_jv6T96xxPKIda8AMxFWvaqQ0BJo6rec-S-USBBhYFcgA"
+        )
+
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
+
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        val authenticatedPayload = Credentials(issuer, signer).authenticateDisclosure(token)
+
+        assert(authenticatedPayload).isNotNull()
+    }
+
+    @Test
+    fun `throws error when req token is missing`() = runBlocking {
+
+        val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1656628378,
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                "net" to "0x4",
+                "own" to mapOf(
+                        "name" to "Mike Gunn",
+                        "email" to "mgunn@uport.me"
+                ),
+                "permissions" to listOf("notifications")
+        )
+
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
+
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        coAssert {
+            Credentials(issuer, signer).authenticateDisclosure(token)
+        }.thrownError {
+            isInstanceOf(JWTAuthenticationException::class)
+        }
+    }
+
+
+    @Test
+    fun `throws error when request type is not a shareReq`() = runBlocking {
+
+        val map = mapOf<String, Any>(
+                "iat" to 1556541978,
+                "exp" to 1656628378,
+                "aud" to "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                "net" to "0x4",
+                "own" to mapOf(
+                        "name" to "Mike Gunn",
+                        "email" to "mgunn@uport.me"
+                ),
+                "permissions" to listOf("notifications"),
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwic3ViIjoiZGlkOmV0aHI6MHgzZmYyNTExN2MwZTE3MGNhNTMwYmQ1ODkxODk5YzE4Mzk0NGRiNDMxIiwidHlwZSI6InZlclJlcSIsInVuc2lnbmVkQ2xhaW0iOnsiY2l0aXplbiBvZiBDbGV2ZXJsYW5kIjp0cnVlfSwiaWF0IjoxNTU3NDA5ODYyLCJleHAiOjE1NTc0MTA0NjIsImlzcyI6ImRpZDpldGhyOjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.EMK2EwA269enwVYA9Nxm8pbfKoyrKOkawlSL5ggK6ISUPOql7ebxDw2vwU8_ebpUq-E6xsp7uEm5ey7nduLxiAE"
+        )
+
+        val signer = KPSigner("0x1234")
+        val issuer = "did:ethr:${signer.getAddress()}"
+
+        val resolver = spyk(EthrDIDResolver(JsonRPC("")))
+
+        coEvery { resolver.resolve(eq(issuer)) } returns EthrDIDDocument.fromJson("""
+            {
+              "@context": "https://w3id.org/did/v1",
+              "id": "$issuer",
+              "publicKey": [{
+                   "id": "$issuer#owner",
+                   "type": "Secp256k1VerificationKey2018",
+                   "owner": "$issuer",
+                   "ethereumAddress": "${signer.getAddress()}"}],
+              "authentication": [{
+                   "type": "Secp256k1SignatureAuthentication2018",
+                   "publicKey": "$issuer#owner"}]
+            }
+        """.trimIndent())
+
+        UniversalDID.registerResolver(resolver)
+
+        val token = JWTTools().createJWT(map, issuer, signer)
+
+        coAssert {
+            Credentials(issuer, signer).authenticateDisclosure(token)
+        }.thrownError {
+            isInstanceOf(JWTAuthenticationException::class)
+        }
+    }
 }

--- a/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
+++ b/credentials/src/test/java/me/uport/sdk/credentials/CredentialsTest.kt
@@ -334,7 +334,7 @@ class CredentialsTest {
                         "email" to "mgunn@uport.me"
                 ),
                 "permissions" to listOf("notifications"),
-                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwic3ViIjoiZGlkOmV0aHI6MHgzZmYyNTExN2MwZTE3MGNhNTMwYmQ1ODkxODk5YzE4Mzk0NGRiNDMxIiwidHlwZSI6InZlclJlcSIsInVuc2lnbmVkQ2xhaW0iOnsiY2l0aXplbiBvZiBDbGV2ZXJsYW5kIjp0cnVlfSwiaWF0IjoxNTU3NDA5ODYyLCJleHAiOjE1NTc0MTA0NjIsImlzcyI6ImRpZDpldGhyOjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.EMK2EwA269enwVYA9Nxm8pbfKoyrKOkawlSL5ggK6ISUPOql7ebxDw2vwU8_ebpUq-E6xsp7uEm5ey7nduLxiAE"
+                "req" to "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjYWxsYmFjayI6Imh0dHBzOi8vdXBvcnQtcHJvamVjdC5naXRodWIuaW8vdXBvcnQtYW5kcm9pZC1zZGsvY2FsbGJhY2tzIiwic3ViIjoiZGlkOmV0aHI6MHgzZmYyNTExN2MwZTE3MGNhNTMwYmQ1ODkxODk5YzE4Mzk0NGRiNDMxIiwidHlwZSI6InZlclJlcSIsInVuc2lnbmVkQ2xhaW0iOnsiY2l0aXplbiBvZiBDbGV2ZXJsYW5kIjp0cnVlfSwiaWF0IjoxNTU3NDE3MTczLCJleHAiOjkwMDAwMDAwMDE1NTc0MTcxNzMsImlzcyI6ImRpZDpldGhyOjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.hR0hmw-63WrTK-dsdzfdGhnleDY59zTIbFYk-V-L2yEoe4fn6piFBbkGeBBfVwxs7iTi679BtY8jA3pDl3OLdwA"
         )
 
         val signer = KPSigner("0x1234")

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTExceptions.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTExceptions.kt
@@ -8,4 +8,11 @@ class JWTEncodingException(message: String) : IllegalArgumentException(message)
 /**
  * Thrown when a JWT is invalid either because it is expired, not valid yet or the signature doesn't match
  */
-class InvalidJWTException(message: String) : IllegalStateException(message)
+open class InvalidJWTException(message: String) : IllegalStateException(message)
+
+/**
+ * Thrown when a JWT authentication fails invalid because the issuer in the response and request do not match,
+ * the request type is not [shareReq]
+ * the request token is not in the response token
+ */
+class JWTAuthenticationException(message: String) : InvalidJWTException(message)


### PR DESCRIPTION
#### What's Here
This PR adds a feature which authenticates the response from a selective disclosure request by 
* [x] Checking to make sure the response JWT contains the request token
* [x] Checking if the identity who receives the response is the identity who initiated the request
* [x] Checking to make sure the request was a `shareReq` type

If any of the above is not satisfied a `JWTAuthenticationException` is thrown
This solves https://www.pivotaltracker.com/story/show/164105045

#### Testing
Run gradle command `./gradlew test cC --no-parallel`