### PR TITLE
[wip] Support new implementation for requesting claims in selective disclosure 

### DIFF
--- a/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
@@ -16,28 +16,28 @@ import me.uport.sdk.credentials.RequestAccountType.*
  */
 class SelectiveDisclosureRequestParams(
     /**
-         * [**required**]
-         * a simple_list of attributes for which you are requesting credentials.
-         * Ex. [ 'name', 'country' ]
-         */
-        val requested: List<String>,
+     * [**required**]
+     * a simple_list of attributes for which you are requesting credentials.
+     * Ex. [ 'name', 'country' ]
+     */
+    val requested: List<String>,
 
     /**
-         * [**required**]
-         * the url that can receive the response to this request.
-         * TODO: detail how that URL should be handled by the APP implementing this SDK
-         *
-         * This gets encoded as `callback` in the JWT payload
-         */
-        val callbackUrl: String,
+     * [**required**]
+     * the url that can receive the response to this request.
+     * TODO: detail how that URL should be handled by the APP implementing this SDK
+     *
+     * This gets encoded as `callback` in the JWT payload
+     */
+    val callbackUrl: String,
 
     /**
-         * [**optional**]
-         * A simple_list of signed claims being requested.
-         * This is semantically similar to the [requested] field
-         * but the response should contain signatures as well.
-         */
-        val verified: List<String>? = null,
+     * [**optional**]
+     * A simple_list of signed claims being requested.
+     * This is semantically similar to the [requested] field
+     * but the response should contain signatures as well.
+     */
+    val verified: List<String>? = null,
 
     /**
      * [**optional**]
@@ -48,56 +48,56 @@ class SelectiveDisclosureRequestParams(
      * [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md#claims-spec)
      *
      */
-    val claims: Map<String, Any>? = null,
+    val claims: Map<String, Any?>? = null,
 
     /**
-         * [**optional**]
-         * The Ethereum network ID if it is relevant for this request.
-         *
-         * This gets encoded as `net` in the JWT payload
-         *
-         * Examples: `"0x4"`, [Networks.mainnet.networkId]
-         */
-        val networkId: String? = null,
+     * [**optional**]
+     * The Ethereum network ID if it is relevant for this request.
+     *
+     * This gets encoded as `net` in the JWT payload
+     *
+     * Examples: `"0x4"`, [Networks.mainnet.networkId]
+     */
+    val networkId: String? = null,
 
 
     /**
-         * [**optional**]
-         * If this request implies a particular kind of account.
-         * This defaults to [RequestAccountType.general] (user choice)
-         *
-         * This gets encoded as `act` in the JWT payload
-         *
-         * @see [RequestAccountType]
-         */
-        val accountType: RequestAccountType? = general,
+     * [**optional**]
+     * If this request implies a particular kind of account.
+     * This defaults to [RequestAccountType.general] (user choice)
+     *
+     * This gets encoded as `act` in the JWT payload
+     *
+     * @see [RequestAccountType]
+     */
+    val accountType: RequestAccountType? = general,
 
     /**
-         * [**optional**]
-         * A list of signed claims about the issuer, usually signed by 3rd parties.
-         */
-        val vc: List<String>? = null,
+     * [**optional**]
+     * A list of signed claims about the issuer, usually signed by 3rd parties.
+     */
+    val vc: List<String>? = null,
 
     /**
-         * [**optional**] defaults to [DEFAULT_SHARE_REQ_VALIDITY_SECONDS]
-         * The validity interval of this request, measured in seconds since the moment it is issued.
-         */
-        val expiresInSeconds: Long? = DEFAULT_SHARE_REQ_VALIDITY_SECONDS,
+     * [**optional**] defaults to [DEFAULT_SHARE_REQ_VALIDITY_SECONDS]
+     * The validity interval of this request, measured in seconds since the moment it is issued.
+     */
+    val expiresInSeconds: Long? = DEFAULT_SHARE_REQ_VALIDITY_SECONDS,
 
 
-        //omitting the "notifications" permission because it has no relevance on android.
-        // It may be worth adding for direct interop with iOS but that is unclear now
+    //omitting the "notifications" permission because it has no relevance on android.
+    // It may be worth adding for direct interop with iOS but that is unclear now
 
     /**
-         * [**optional**]
-         * This can hold extra fields for the JWT payload representing the request.
-         * Use this to provide any of the extra fields described in the
-         * [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
-         *
-         * The fields contained in [extras] will get overwritten by the named parameters
-         * in this class in case of a name collision.
-         */
-        val extras: Map<String, Any>? = null
+     * [**optional**]
+     * This can hold extra fields for the JWT payload representing the request.
+     * Use this to provide any of the extra fields described in the
+     * [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)
+     *
+     * The fields contained in [extras] will get overwritten by the named parameters
+     * in this class in case of a name collision.
+     */
+    val extras: Map<String, Any>? = null
 )
 
 /**
@@ -128,6 +128,7 @@ internal fun buildPayloadForShareReq(params: SelectiveDisclosureRequestParams): 
     val payload = params.extras.orEmpty().toMutableMap()
 
     payload["callback"] = params.callbackUrl
+    payload["claims"] = params.claims.orEmpty().toMutableMap()
     payload["requested"] = params.requested
     params.verified?.let { payload["verified"] = it }
     params.vc?.let { payload["vc"] = it }

--- a/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/SelectiveDisclosureRequestParams.kt
@@ -2,11 +2,7 @@
 
 package me.uport.sdk.credentials
 
-import me.uport.sdk.credentials.RequestAccountType.devicekey
-import me.uport.sdk.credentials.RequestAccountType.general
-import me.uport.sdk.credentials.RequestAccountType.keypair
-import me.uport.sdk.credentials.RequestAccountType.none
-import me.uport.sdk.credentials.RequestAccountType.segregated
+import me.uport.sdk.credentials.RequestAccountType.*
 
 /**
  * A class that encapsulates the supported parameter types for creating a SelectiveDisclosureRequest.
@@ -19,14 +15,14 @@ import me.uport.sdk.credentials.RequestAccountType.segregated
  * and ease of use of frequently used params.
  */
 class SelectiveDisclosureRequestParams(
-        /**
+    /**
          * [**required**]
          * a simple_list of attributes for which you are requesting credentials.
          * Ex. [ 'name', 'country' ]
          */
         val requested: List<String>,
 
-        /**
+    /**
          * [**required**]
          * the url that can receive the response to this request.
          * TODO: detail how that URL should be handled by the APP implementing this SDK
@@ -35,7 +31,7 @@ class SelectiveDisclosureRequestParams(
          */
         val callbackUrl: String,
 
-        /**
+    /**
          * [**optional**]
          * A simple_list of signed claims being requested.
          * This is semantically similar to the [requested] field
@@ -43,7 +39,18 @@ class SelectiveDisclosureRequestParams(
          */
         val verified: List<String>? = null,
 
-        /**
+    /**
+     * [**optional**]
+     * This allows you to request claims with very specific properties.
+     * This replaces the [requested] and [verified] parameters of this request.
+     * You may still include requested and verified to provide support for older clients.
+     * But they will be ignored if by newer clients if the claims field is present
+     * [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md#claims-spec)
+     *
+     */
+    val claims: Map<String, Any>? = null,
+
+    /**
          * [**optional**]
          * The Ethereum network ID if it is relevant for this request.
          *
@@ -54,7 +61,7 @@ class SelectiveDisclosureRequestParams(
         val networkId: String? = null,
 
 
-        /**
+    /**
          * [**optional**]
          * If this request implies a particular kind of account.
          * This defaults to [RequestAccountType.general] (user choice)
@@ -65,13 +72,13 @@ class SelectiveDisclosureRequestParams(
          */
         val accountType: RequestAccountType? = general,
 
-        /**
+    /**
          * [**optional**]
          * A list of signed claims about the issuer, usually signed by 3rd parties.
          */
         val vc: List<String>? = null,
 
-        /**
+    /**
          * [**optional**] defaults to [DEFAULT_SHARE_REQ_VALIDITY_SECONDS]
          * The validity interval of this request, measured in seconds since the moment it is issued.
          */
@@ -81,7 +88,7 @@ class SelectiveDisclosureRequestParams(
         //omitting the "notifications" permission because it has no relevance on android.
         // It may be worth adding for direct interop with iOS but that is unclear now
 
-        /**
+    /**
          * [**optional**]
          * This can hold extra fields for the JWT payload representing the request.
          * Use this to provide any of the extra fields described in the

--- a/demoapp/src/main/java/me/uport/sdk/demoapp/request_flows/uPortLoginActivity.kt
+++ b/demoapp/src/main/java/me/uport/sdk/demoapp/request_flows/uPortLoginActivity.kt
@@ -8,17 +8,13 @@ import kotlinx.android.synthetic.main.activity_uport_login.*
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import me.uport.sdk.signer.KPSigner
 import me.uport.sdk.core.UI
 import me.uport.sdk.credentials.Credentials
 import me.uport.sdk.credentials.SelectiveDisclosureRequestParams
 import me.uport.sdk.demoapp.R
 import me.uport.sdk.jwt.JWTTools
-import me.uport.sdk.transport.ErrorUriResponse
-import me.uport.sdk.transport.JWTUriResponse
-import me.uport.sdk.transport.ResponseParser
-import me.uport.sdk.transport.Transports
-import me.uport.sdk.transport.UriResponse
+import me.uport.sdk.signer.KPSigner
+import me.uport.sdk.transport.*
 
 /**
  * This allows the users initiate a uPort login using [SelectiveDisclosureRequest]
@@ -36,11 +32,48 @@ class uPortLoginActivity : AppCompatActivity() {
         // create a DID
         val issuerDID = "did:ethr:${signer.getAddress()}"
 
+        val claim = mapOf(
+            "verifiable" to mapOf(
+                "email" to mapOf(
+                    "iss" to listOf(
+                        mapOf(
+                            "did" to "did:web:uport.claims",
+                            "url" to "https://uport.claims/email"
+                        ),
+                        mapOf(
+                            "did" to "did:web:sobol.io",
+                            "url" to "https://sobol.io/verify"
+                        )
+                    ),
+                    "reason" to "Whe need to be able to email you",
+                    "essential" to false
+                ),
+                "nationalIdentity" to mapOf(
+                    "iss" to listOf(
+                        mapOf(
+                            "did" to "did:web:idverifier.claims",
+                            "url" to "https://idverifier.example"
+                        )
+                    ),
+                    "reason" to "To legally be able to open your account",
+                    "essential" to true
+                ),
+                "user_info" to mapOf(
+                    "name" to mapOf(
+                        "essential" to true,
+                        "reason" to "Show your name to other users"
+                    ),
+                    "country" to null
+                )
+            )
+        )
+
         // create the request JWT
         val cred = Credentials(issuerDID, signer)
         val params = SelectiveDisclosureRequestParams(
-                requested = listOf("name"),
-                callbackUrl = "https://uport-project.github.io/uport-android-sdk/callbacks"
+            requested = listOf("name"),
+            callbackUrl = "https://uport-project.github.io/uport-android-sdk/callbacks",
+            claims = claim
         )
 
         request_details.text = """


### PR DESCRIPTION
#### What's here
Added a new `claims` param to the payload when making selective disclosure requests. This keeps us up to date with the latest changes in the specs [Selective Disclosure Request](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md)

#### In Progress
1. Building a helper class to make it easier for developers to create claims while making requests
2. Adding Tests
