### PR TITLE
[support] bump kethereum to 0.76.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ val receipt = Networks.rinkeby.awaitConfirmation(txHash)
 
 ```
 
-### off-chain interaction
+### Off-chain interaction
 
 Off-chain interaction is essentially signing and verifying JWTs using specific JWT algorithms.
 Verification of such tokens implies resolving a 
@@ -141,7 +141,7 @@ Registering a new resolver that resolves the same DID method will override the p
 
 These `DIDDocument`s are used during verification of compatible JWT tokens.
 
-#### verify a JWT token
+#### Verify a JWT token
 
 ```kotlin
 
@@ -157,7 +157,7 @@ if (tokenPayload != null) {
 ```
 
 
-#### create a JWT token
+#### Create a JWT token
 
 ```kotlin
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.3.41'
-        kotlin_serialization_version = '0.11.0'
-        coroutines_version = "1.2.1"
+        kotlin_version = '1.3.50'
+        kotlin_serialization_version = '0.12.0'
+        coroutines_version = "1.3.1"
 
-        android_tools_version = '3.4.2'
+        android_tools_version = '3.5.1'
 
         build_tools_version = "28.0.3"
 
@@ -35,12 +35,12 @@ buildscript {
         okhttp_version = "3.14.1"
 
         bivrost_version = "v0.7.1"
-        kmnid_version = "0.3.2"
-        kethereum_version = "0.75.1"
+        kmnid_version = "0.4.2"
+        kethereum_version = "0.76.2"
         tweetnacl_k_version = "0.0.1"
-        did_jwt_version = "0.3.1"
-        kotlin_common_version = "0.1.1"
-        uport_signer_version = "0.3.0"
+        did_jwt_version = "0.3.3"
+        kotlin_common_version = "0.3.2"
+        uport_signer_version = "0.3.6"
 
         uport_sdk_version = "0.5.1"
 
@@ -126,9 +126,6 @@ allprojects {
                 details.useVersion kotlin_version
             }
         }
-
-        //XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
-        exclude group: "com.github.walleth"
     }
 }
 
@@ -141,6 +138,14 @@ subprojects { subproject ->
                 packagingOptions {
                     exclude "META-INF/main.kotlin_module"
                     exclude "META-INF/atomicfu.kotlin_module"
+                    pickFirst "META-INF/kotlinx-io.kotlin_module"
+                    pickFirst "META-INF/kbignumbers.kotlin_module"
+                    pickFirst "META-INF/ripemd160.kotlin_module"
+                    pickFirst "META-INF/extensions.kotlin_module"
+                    pickFirst "META-INF/core.kotlin_module"
+                    pickFirst "META-INF/keccak.kotlin_module"
+                    pickFirst "META-INF/sha256.kotlin_module"
+                    pickFirst "META-INF/khash-extensions.kotlin_module"
                 }
 
                 compileOptions {

--- a/credentials/src/main/java/me/uport/sdk/credentials/model/CredentialParams.kt
+++ b/credentials/src/main/java/me/uport/sdk/credentials/model/CredentialParams.kt
@@ -1,5 +1,6 @@
 package me.uport.sdk.credentials.model
 
+import kotlinx.serialization.ContextualSerialization
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -27,7 +28,7 @@ data class CredentialParams(
     @Required
     @SerialName("credentialSubject")
     @Serializable(with = ArbitraryMapSerializer::class)
-    val credentialSubject: Map<String, Any>,
+    val credentialSubject: Map<String, @ContextualSerialization Any>,
 
     /**
      * The LD context hooks.

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -42,8 +42,8 @@ configurations.all {
 
 dependencies {
 
-//    implementation "com.github.uport-project.uport-android-sdk:sdk:$uport_sdk_version"
-    implementation project(":sdk")
+    implementation "com.github.uport-project.uport-android-sdk:sdk:$uport_sdk_version"
+//    implementation project(":sdk")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -37,9 +37,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
     implementation "com.android.support:support-annotations:$support_lib_version"
 
-    api "com.github.komputing.KEthereum:model:$kethereum_version"
+    api "com.github.komputing.kethereum:model:$kethereum_version"
     api "com.github.uport-project.kotlin-common:core:$kotlin_common_version"
     api "com.github.uport-project:uport-android-signer:$uport_signer_version"
+    api "com.github.uport-project:kmnid:$kmnid_version"
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_runner_version"

--- a/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
+++ b/identity/src/test/java/me/uport/sdk/identity/AccountsTests.kt
@@ -97,7 +97,7 @@ class AccountsTests {
                 "devKey": "0x95979bb3ee68420a0b105f6e3c0d5d0fc0466016",
                 "network": "0x04",
                 "proxy": "0x95979bb3ee68420a0b105f6e3c0d5d0fc0466016",
-                "signerType": "HDKeyPair",
+                "signerType": "HDKeyPair"
             }""".trimIndent()
 
         val account = HDAccount.fromJson(serializedAccount)

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$bivrost_version"
 
+    implementation "com.github.komputing.kethereum:functions:$kethereum_version"
     api "com.github.uport-project.kotlin-did-jwt:jwt:$did_jwt_version"
     api project(":credentials")
     api project(":transport")

--- a/sdk/src/main/java/me/uport/sdk/Transactions.kt
+++ b/sdk/src/main/java/me/uport/sdk/Transactions.kt
@@ -25,7 +25,7 @@ import org.kethereum.functions.encodeRLP
 import org.kethereum.model.Address
 import org.kethereum.model.Transaction
 import org.kethereum.model.createTransactionWithDefaults
-import org.walleth.khex.toHexString
+import org.komputing.khex.extensions.toHexString
 import java.math.BigInteger
 
 val DEFAULT_GAS_LIMIT = 3_000_000L.toBigInteger()

--- a/sdk/src/main/java/me/uport/sdk/extensions/TransactionExtensions.kt
+++ b/sdk/src/main/java/me/uport/sdk/extensions/TransactionExtensions.kt
@@ -12,7 +12,7 @@ import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
 import org.kethereum.model.Address
 import org.kethereum.model.createTransactionWithDefaults
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 import java.math.BigInteger
 
 /**

--- a/sdk/src/main/java/me/uport/sdk/signer/TxRelaySigner.kt
+++ b/sdk/src/main/java/me/uport/sdk/signer/TxRelaySigner.kt
@@ -12,9 +12,9 @@ import org.kethereum.model.Address
 import org.kethereum.model.SignatureData
 import org.kethereum.model.Transaction
 import org.kethereum.model.createTransactionWithDefaults
-import org.walleth.khex.clean0xPrefix
-import org.walleth.khex.hexToByteArray
-import org.walleth.khex.toNoPrefixHexString
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.hexToByteArray
+import org.komputing.khex.extensions.toNoPrefixHexString
 import java.math.BigInteger
 
 /**

--- a/transport/src/test/java/me/uport/sdk/transport/CryptoTest.kt
+++ b/transport/src/test/java/me/uport/sdk/transport/CryptoTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isZero
 import org.junit.Test
-import org.walleth.khex.hexToByteArray
+import org.komputing.khex.extensions.hexToByteArray
 
 
 class CryptoTest {


### PR DESCRIPTION
This is a maintenance PR, updating dependencies and migrating to the lowercase coordinates.

There are no functionality changes. All tests were kept and pass.